### PR TITLE
fix: Correct Table container CSS width

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -79,6 +79,8 @@ export default {
             'util',
             'assets',
             'refactor',
+            'fix',
+            'chore',
           ];
 
           const topics = type.split(',').map((t) => t.trim());

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -10,10 +10,7 @@ export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {
 
 const Table = React.forwardRef<HTMLTableElement, TableProps>(
   ({ className, children, loading, ...props }, ref) => (
-    <div
-      className="border-surface-default bg-surface-primary relative w-max
-        border"
-    >
+    <div className="border-surface-default bg-surface-primary relative border">
       <table
         ref={ref}
         className={cn('w-full caption-bottom', className)}


### PR DESCRIPTION
## issue information
While working on he department table I noticed a small issue for the `Table` component container width.
I corrected it by removing the `w-max` class.

## Note
I also added `fix` and `chore` to the `validTopics` list as those are used for the [conventional commits convention](https://www.conventionalcommits.org/en/v1.0.0/#specification).
