### PR TITLE
Small fix for FormField component

### DIFF
--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -32,15 +32,12 @@ export const FormField: React.FC<FormFieldProps> = ({
     : children;
 
   return (
-    <div className="flex flex-col">
+    <div className={cn('flex w-full flex-col', className)}>
       {label && (
         <label
           htmlFor={name}
-          className={cn(
-            `text-body-secondary gap-xxs pb-xs text-sm font-normal flex
-            items-center leading-none`,
-            className
-          )}
+          className="text-body-secondary gap-xxs pb-xs text-sm font-normal flex
+            items-center leading-none"
         >
           <span>{label}</span>
           {optional && <span className="text-body-secondary">(任意)</span>}


### PR DESCRIPTION
## issue information
This PR adjusts the <FormField /> component to attach the `className` to the outer container, instead of the inner label element.

## Overview
- Attach `className` to outer container
- Add `w-full` as default style, since it aligns better with real-world usage

## Dependencies
None

## Step to test
- Add a `className` prop to the `<FormField />`
- See the styles attached to the outer container, instead of label element

## Additional information
Noticed this will replacing the custom markup with <FormField /> in the SDS Filter Panel and being stuck with the default width of the component.