### PR TITLE
refactor(Tag): Expose TagColorCode type

### DIFF
--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -32,12 +32,13 @@ const colorCodeToTokenMap = {
   18: [ColorShapeTokens.AccentGrayPale, ColorTextTokens.AccentGrayStrong],
 } as const;
 
+export type TagColorCode = keyof typeof colorCodeToTokenMap;
 export interface TagProps {
   className?: string;
   children?: React.ReactNode;
   onRemove?: () => void;
   onClick?: () => void;
-  colorCode?: keyof typeof colorCodeToTokenMap;
+  colorCode?: TagColorCode;
   size?: 'sm' | 'md';
   style?: React.CSSProperties;
   selected?: boolean;


### PR DESCRIPTION
## issue information
The `TagColorCode` is needed in our project for clarity and avoid what we have in the `getValidColorCode` .
This would help on the readability of our code as well.


## Before change
Need to catch manually all the code for the TagColorCode

```typescript
const getValidColorCode = (color?: number): 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 => {
  if (color && color >= 1 && color <= 18) {
    // prettier-ignore
    return color as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18;
  }
  return 0;
};
```


## After change
Just need to use the dedicated type

```typescript
const getValidColorCode = (color?: number): TagColorCode => {
  if (color && color >= 1 && color <= 18) {
    // prettier-ignore
    return color as TagColorCode;
  }
  return 0;
};
```
