### PR TITLE
fix(doc): Set autodocs tag to all components

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -20,6 +20,7 @@ const preview: Preview = {
       },
     },
   },
+  tags: ['autodocs'],
 };
 
 export default preview;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ import eslintParserTypeScript from '@typescript-eslint/parser';
 import eslintPluginBetterTailwindcss from 'eslint-plugin-better-tailwindcss';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', '.storybook'] },
   {
     extends: [
       js.configs.recommended,

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof Badge> = {
   parameters: {
     layout: 'padded',
   },
-  tags: ['autodocs'],
   argTypes: {
     intent: {
       control: 'select',

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -21,7 +21,6 @@ const iconMap = {
 const meta: Meta<typeof Button> = {
   title: 'Components/Button',
   component: Button,
-  tags: ['autodocs'],
   argTypes: {
     children: {
       control: { type: 'text' },

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -49,7 +49,6 @@ const meta: Meta<typeof DatePicker> = {
       defaultValue: false,
     },
   },
-  tags: [],
 };
 
 export default meta;

--- a/src/components/Dialog/MultiStepDialog.stories.tsx
+++ b/src/components/Dialog/MultiStepDialog.stories.tsx
@@ -11,7 +11,6 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 } satisfies Meta<typeof MultiStepDialog.Root>;
 
 export default meta;

--- a/src/components/FormField/FormField.stories.tsx
+++ b/src/components/FormField/FormField.stories.tsx
@@ -10,7 +10,6 @@ const meta: Meta<typeof FormField> = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
   argTypes: {
     label: {
       control: 'text',

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -25,7 +25,6 @@ const meta: Meta<typeof MultiSelect> = {
       },
     },
   },
-  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',

--- a/src/components/TextLink/TextLink.stories.tsx
+++ b/src/components/TextLink/TextLink.stories.tsx
@@ -16,7 +16,6 @@ const meta: Meta<typeof TextLink> = {
   parameters: {
     layout: 'padded',
   },
-  tags: ['autodocs'],
   argTypes: {
     intent: {
       control: 'select',

--- a/src/icons/CustomIcons.stories.tsx
+++ b/src/icons/CustomIcons.stories.tsx
@@ -9,7 +9,6 @@ import {
 
 const meta: Meta = {
   title: 'Components/Custom Icons',
-  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {

--- a/src/icons/TablerIcons.stories.tsx
+++ b/src/icons/TablerIcons.stories.tsx
@@ -29,7 +29,6 @@ import { Button } from '../components/Button';
 
 const meta: Meta = {
   title: 'Components/Tabler Icons',
-  tags: ['autodocs'],
   parameters: {
     docs: {
       description: {


### PR DESCRIPTION
## issue information
<!--
* githubのissueタイトルとURL
* slackでのコミュニケーションログ
* Notionでの関連ドキュメントリンクなど
-->

## Overview
As title says

Autodocs tag is already set some comopnents, but Not for all components.
You can see all document of component on storybook now.

<img width="1123" height="835" alt="スクリーンショット 2025-11-24 16 29 22" src="https://github.com/user-attachments/assets/ac8d0abb-953e-406b-9287-27979b6c4a3b" />

<!--
* 変更の理由や内容の説明
-->
## Dependencies
<!--
* 変更の影響を受けると考えられる機能や環境
-->

## Step to test
<!--
* 動作確認手順
-->

## Additional information
<!--
* 特にレビューしてほしいポイントなどの補足情報
-->
