### PR TITLE
refactor(Tag): Change mapping structure to match old and new colors

### DIFF
--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { Meta, StoryFn } from 'storybook/react-vite';
 
 import type { TagProps } from './Tag';
-import { colorCodeToMap, Tag } from './Tag';
+import { colorCodeToTokenMap, Tag } from './Tag';
 
 const meta: Meta<typeof Tag> = {
   title: 'Components/Tag',
@@ -82,7 +82,7 @@ export const ColorCodeShowcase: StoryFn<{ selected?: boolean }> = ({
 }) => {
   // Get unique color codes and sort them
   const uniqueColorCodes = Array.from(
-    new Set(colorCodeToMap.map((c) => c.code))
+    new Set(colorCodeToTokenMap.map((c) => c.code))
   ).sort((a, b) => a - b);
 
   return (

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -6,7 +6,7 @@ import { cn } from '../../utils';
 
 // Mapping the color codes for user defined tag colors to our design tokens
 // Reference: https://docs.google.com/spreadsheets/d/14r5PJTfzfESsKypY2cJlR65I2-DkO4RvODa04x_s1dA
-export const colorCodeToMap = [
+export const colorCodeToTokenMap = [
   {
     backgroundColor: ColorShapeTokens.AccentSunSoft,
     textColor: ColorTextTokens.AccentSunStrong,
@@ -191,7 +191,7 @@ export const colorCodeToMap = [
   },
 ] as const;
 
-export type TagColorCode = (typeof colorCodeToMap)[number]['code'];
+export type TagColorCode = (typeof colorCodeToTokenMap)[number]['code'];
 
 export interface TagProps {
   className?: string;
@@ -238,7 +238,7 @@ export const Tag: React.FC<TagProps> = ({
   style,
   selected = false,
 }) => {
-  const colorMapping = colorCodeToMap.find(
+  const colorMapping = colorCodeToTokenMap.find(
     (colorMap) => colorMap.code === colorCode
   );
 


### PR DESCRIPTION
## issue information
With the company tags settings page, it seems we have a lot more colors available than originally.

I updated the color mapping Object into an Array that is matching the [design on Figma](https://www.figma.com/design/f46iSbgpNKClOOIDRfG7AB/Master-v2.0-SDS%E7%AE%A1%E7%90%86%EF%BC%88JP_Products%EF%BC%89?node-id=7335-3678&t=Isr8KKplDd3cjarP-4) for the color selection.

## Before change
Only the set of legacy colors

## After change
Set of legacy and new colors in ann array order by color shades.

See screenshot for the application of this change

<img width="1049" height="766" alt="Screenshot 2025-11-26 at 17 51 37" src="https://github.com/user-attachments/assets/d790bdab-9938-4c1f-95e5-c3a4c7cba0a0" />


## Tests
Update code color showcase story with all the new colors and their codes.


