### PR TITLE
refactor(MultiSelect): ♻️ Update the MultiSelect to be more flexible

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -798,3 +798,104 @@ const selectedLabels = selectedValues
     },
   },
 };
+
+export const InlineSelectionDisplay: Story = {
+  args: {
+    options: basicOptions,
+    placeholder: 'Select fruits...',
+    selectionDisplayMode: 'inline',
+    defaultValue: [
+      '550e8400-e29b-41d4-a716-446655440001',
+      '550e8400-e29b-41d4-a716-446655440002',
+    ],
+    onValueChange: (values) => console.log('Selected values:', values),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This story demonstrates the inline selection display mode. When selectionDisplayMode is set to "inline", selected values are displayed as comma-separated text within the trigger button instead of as badge elements below it. This provides a more compact layout that is suitable for space-constrained interfaces.',
+      },
+      source: {
+        code: `import { MultiSelect } from '@chemican/components';
+
+<MultiSelect
+  options={options}
+  placeholder="Select fruits..."
+  selectionDisplayMode="inline"
+  defaultValue={['apple', 'banana']}
+  onValueChange={(values) => console.log('Selected values:', values)}
+/>`,
+      },
+    },
+  },
+};
+
+const InlineSelectionComparisonComponent = () => {
+  return (
+    <div className="gap-6 flex flex-col">
+      <div className="gap-2 flex flex-col">
+        <h3 className="font-semibold text-body-primary">
+          Default Mode (Badges Below)
+        </h3>
+        <MultiSelect
+          options={basicOptions}
+          placeholder="Select fruits..."
+          selectionDisplayMode="default"
+          defaultValue={[
+            '550e8400-e29b-41d4-a716-446655440001',
+            '550e8400-e29b-41d4-a716-446655440002',
+            'cherry-fruit',
+          ]}
+        />
+      </div>
+
+      <div className="gap-2 flex flex-col">
+        <h3 className="font-semibold text-body-primary">
+          Inline Mode (Inside Trigger)
+        </h3>
+        <MultiSelect
+          options={basicOptions}
+          placeholder="Select fruits..."
+          selectionDisplayMode="inline"
+          defaultValue={[
+            '550e8400-e29b-41d4-a716-446655440001',
+            '550e8400-e29b-41d4-a716-446655440002',
+            'cherry-fruit',
+          ]}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const InlineSelectionComparison: Story = {
+  render: () => <InlineSelectionComparisonComponent />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This story compares the two selection display modes side by side. The default mode shows selected items as removable badges below the trigger button, while the inline mode displays them as comma-separated text within the trigger button itself. Use inline mode when you need a more compact layout or when badge removal functionality is not needed in the trigger area.',
+      },
+      source: {
+        code: `import { MultiSelect } from '@chemican/components';
+
+// Default mode - badges below trigger
+<MultiSelect
+  options={options}
+  placeholder="Select fruits..."
+  selectionDisplayMode="default"
+  defaultValue={['apple', 'banana', 'cherry']}
+/>
+
+// Inline mode - text inside trigger
+<MultiSelect
+  options={options}
+  placeholder="Select fruits..."
+  selectionDisplayMode="inline"
+  defaultValue={['apple', 'banana', 'cherry']}
+/>`,
+      },
+    },
+  },
+};

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -322,6 +322,19 @@ interface MultiSelectProps<T = string | number>
   hideSelection?: boolean;
 
   /**
+   * Controls how selected values are displayed in the component.
+   * - 'default': Shows selected items as removable badge components below the trigger button
+   * - 'inline': Displays selected items as comma-separated text within the trigger button itself
+   *
+   * Use 'inline' mode for more compact layouts or when badge removal functionality
+   * is not needed in the trigger area. The 'default' mode provides better visual
+   * feedback and individual item removal capabilities.
+   *
+   * Optional, defaults to 'default'.
+   */
+  selectionDisplayMode?: 'default' | 'inline';
+
+  /**
    * Custom render function for option content.
    * Allows customization of how options appear in both the dropdown and as selected badges.
    * If not provided, uses default rendering with label and optional icon.
@@ -410,6 +423,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
     filterByValueAndLabel = false,
     renderOption,
     customTrigger,
+    selectionDisplayMode = 'default',
     hideSelection = false,
     ...props
   }: MultiSelectProps<T>,
@@ -752,6 +766,16 @@ const MultiSelectInner = <T extends string | number = string | number>(
 
   const widthConstraints = getWidthConstraints();
 
+  const triggerText = React.useMemo(() => {
+    if (selectionDisplayMode === 'default' || selectedValues.length === 0)
+      return placeholder;
+
+    return selectedValues
+      .map((v) => getOptionByValue(v)?.label)
+      .filter(Boolean)
+      .join(', ');
+  }, [selectedValues, getOptionByValue, placeholder, selectionDisplayMode]);
+
   React.useEffect(() => {
     if (!isPopoverOpen) {
       setSearchValue('');
@@ -887,14 +911,17 @@ const MultiSelectInner = <T extends string | number = string | number>(
                   <span
                     className={cn(
                       'mx-sm',
+                      selectionDisplayMode === 'inline' && 'truncate',
                       disabled
                         ? 'text-body-disabled'
-                        : isPopoverOpen
+                        : isPopoverOpen ||
+                            (selectionDisplayMode === 'inline' &&
+                              triggerText !== placeholder)
                           ? 'text-body-primary'
                           : 'text-body-placeholder'
                     )}
                   >
-                    {placeholder}
+                    {triggerText}
                   </span>
                   <IconChevronDown
                     className={cn(
@@ -907,7 +934,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
             )}
           </PopoverTrigger>
 
-          {!hideSelection && (
+          {!(hideSelection || selectionDisplayMode === 'inline') && (
             <div className="gap-xxs mt-xxs flex flex-wrap">
               {selectedValues
                 .slice(0, responsiveSettings.maxCount)
@@ -989,8 +1016,8 @@ const MultiSelectInner = <T extends string | number = string | number>(
 
             <CommandList
               className={cn(
-                'max-h-[40vh] overflow-y-auto',
-                screenSize === 'mobile' && 'max-h-[50vh]'
+                'max-h-[calc(40vh-56px)] overflow-y-auto',
+                screenSize === 'mobile' && 'max-h-[calc(50vh-56px)]'
               )}
               style={{ overscrollBehaviorY: 'contain' }}
             >


### PR DESCRIPTION
## issue information
Update the `MultiSelect` component to
- Permit a custom trigger (eg: SDS Upload list to select multiple tags)
- Use Generic type for MultiSelectOption, to handle `string` or `number` for the values
- Add a new key `[key: string]: unknown;` to manage extra key for `renderOptions` (eg: tag color).
- Create a `onApplySelection` to apply change on click apply button instead of selection
- Create `selectionDisplayMode` with an inline version (for @kazk1210 needs based on this [PR](https://github.com/GoodMoneyger/chemican_components/pull/31))

## Note
I noticed a lot of code that would be useful only if we were to maintain a public component library.
We are maintaining a library for Chemican design system therefore I removed some. 
I think we could remove even more, but that would 
If we really need those we could implement those back again.

## Test
New stories for the new props.