### PR TITLE
fix(Dialog): Correct PopoverContent issue within Dialog

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -80,71 +80,73 @@ export const Dialog: React.FC<DialogProps> = ({
         <RadixDialog.Overlay
           className="bg-surface-scrimmed top-0 left-0 z-dialog fixed h-full
             w-full"
-        />
-        <RadixDialog.Content
-          aria-describedby={undefined}
-          onPointerDownOutside={(e) => {
-            if (!cancellable || busyState) {
-              e.preventDefault();
-            }
-          }}
-          className="bg-surface-primary rounded-lg z-dialog max-w-screen-sm
-            min-w-96 fixed top-1/2 left-1/2 flex max-h-[90vh] w-2/3
-            -translate-x-1/2 -translate-y-1/2 transform flex-col"
         >
-          <div
-            className="px-xl py-lg flex flex-shrink-0 items-center
-              justify-between"
+          <RadixDialog.Content
+            aria-describedby={undefined}
+            onPointerDownOutside={(e) => {
+              if (!cancellable || busyState) {
+                e.preventDefault();
+              }
+            }}
+            className="bg-surface-primary rounded-lg z-dialog max-w-screen-sm
+              min-w-96 fixed top-1/2 left-1/2 flex max-h-[90vh] w-2/3
+              -translate-x-1/2 -translate-y-1/2 transform flex-col
+              overflow-auto"
           >
-            {title && (
-              <RadixDialog.Title
-                className="text-xxl text-body-primary font-bold h-4.5 flex
-                  items-center"
-              >
-                {title}
-              </RadixDialog.Title>
-            )}
-          </div>
-          <div
-            className="border-divider-default bg-surface-secondary px-xl pt-md
-              pb-xxl text-body-primary min-h-40 flex-1 overflow-y-auto
-              border-y-1"
-          >
-            {children}
-          </div>
-          <div className="px-xl py-md flex flex-shrink-0 justify-between">
-            {cancellable && (
-              <RadixDialog.Close asChild>
-                <Button
-                  intent="tertiary"
-                  onClick={handleCancelClick}
-                  disabled={busyState}
+            <div
+              className="px-xl py-lg flex flex-shrink-0 items-center
+                justify-between"
+            >
+              {title && (
+                <RadixDialog.Title
+                  className="text-xxl text-body-primary font-bold h-4.5 flex
+                    items-center"
                 >
-                  {cancelButtonLabel}
-                </Button>
-              </RadixDialog.Close>
-            )}
-            <div className={`gap-xs flex ${!cancellable ? 'ml-auto' : ''}`}>
-              {actions.map((action, index) => {
-                const { label, classNames, onAction, value, ...buttonProps } =
-                  action;
-
-                return (
-                  <Button
-                    key={index}
-                    loading={loading === index}
-                    {...buttonProps}
-                    intent={action.intent || 'primary'}
-                    className={classNames}
-                    onClick={() => handleActionClick(action)}
-                  >
-                    {label}
-                  </Button>
-                );
-              })}
+                  {title}
+                </RadixDialog.Title>
+              )}
             </div>
-          </div>
-        </RadixDialog.Content>
+            <div
+              className="border-divider-default bg-surface-secondary px-xl pt-md
+                pb-xxl text-body-primary min-h-40 flex-1 overflow-y-auto
+                border-y-1"
+            >
+              {children}
+            </div>
+            <div className="px-xl py-md flex flex-shrink-0 justify-between">
+              {cancellable && (
+                <RadixDialog.Close asChild>
+                  <Button
+                    intent="tertiary"
+                    onClick={handleCancelClick}
+                    disabled={busyState}
+                  >
+                    {cancelButtonLabel}
+                  </Button>
+                </RadixDialog.Close>
+              )}
+              <div className={`gap-xs flex ${!cancellable ? 'ml-auto' : ''}`}>
+                {actions.map((action, index) => {
+                  const { label, classNames, onAction, value, ...buttonProps } =
+                    action;
+
+                  return (
+                    <Button
+                      key={index}
+                      loading={loading === index}
+                      {...buttonProps}
+                      intent={action.intent || 'primary'}
+                      className={classNames}
+                      onClick={() => handleActionClick(action)}
+                    >
+                      {label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </div>
+          </RadixDialog.Content>
+        </RadixDialog.Overlay>
       </RadixDialog.Portal>
     </RadixDialog.Root>
   );

--- a/src/components/Dialog/MultiStepDialog.tsx
+++ b/src/components/Dialog/MultiStepDialog.tsx
@@ -96,17 +96,20 @@ const Root: React.FC<MultiStepDialogRootProps> = ({
   return (
     <MultiStepDialogContext.Provider value={contextValue}>
       <RadixDialog.Root open={isOpen} onOpenChange={handleClose}>
-        <RadixDialog.Overlay
-          className="bg-surface-scrimmed top-0 left-0 z-dialog fixed h-full
-            w-full"
-        />
-        <RadixDialog.Content
-          className="bg-surface-primary rounded-lg z-dialog max-w-screen-sm
-            min-w-96 fixed top-1/2 left-1/2 w-2/3 -translate-x-1/2
-            -translate-y-1/2 transform"
-        >
-          {steps[currentStep]}
-        </RadixDialog.Content>
+        <RadixDialog.Portal>
+          <RadixDialog.Overlay
+            className="bg-surface-scrimmed top-0 left-0 z-dialog fixed h-full
+              w-full"
+          >
+            <RadixDialog.Content
+              className="bg-surface-primary rounded-lg z-dialog max-w-screen-sm
+                min-w-96 fixed top-1/2 left-1/2 w-2/3 -translate-x-1/2
+                -translate-y-1/2 transform overflow-auto"
+            >
+              {steps[currentStep]}
+            </RadixDialog.Content>
+          </RadixDialog.Overlay>
+        </RadixDialog.Portal>
       </RadixDialog.Root>
     </MultiStepDialogContext.Provider>
   );


### PR DESCRIPTION
## issue information
While working on the `MultiSelect` component I noticed that its not possible to scroll when open within a Dialog component.
This PR fix that issue

## Note
The MultipleDialog component was not using `Portal`. I changed that to be consistent with our `Dialog` and avoid potential `z-index` issue in the future.


## Before change
https://github.com/user-attachments/assets/473a2201-06ae-4a5d-a7b7-dfe7f3eb78ea


## After change
https://github.com/user-attachments/assets/99e8d9c6-c274-4be4-80ec-3b6c952d96af

