### PR TITLE
feat(Table): Add table editable row

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from '../StatusIndicator/StatusIndicator';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { Tag } from '../Tag';
+import { Button } from '../Button';
 
 import {
   Table,
@@ -17,6 +18,7 @@ import {
   TableBody,
   TableCell,
   TableHeadSortButton,
+  TableEditableRow,
 } from './Table';
 
 type DataEntry = {
@@ -495,6 +497,43 @@ export const Default = Template.bind({});
 Default.args = {
   data,
 };
+
+const EditableTemplate: StoryFn = () => {
+  const ActionComponent = (
+    <>
+      <Button size="xs" intent="secondary">
+        編集
+      </Button>
+      <Button size="xs" intent="primary">
+        削除
+      </Button>
+    </>
+  );
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>氏名</TableHead>
+          <TableHead>所属</TableHead>
+          <TableHead>メールアドレス</TableHead>
+          <TableHead>作成日</TableHead>
+          <TableHead>ステータス</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableEditableRow actionComponent={ActionComponent}>
+          <TableCell>テスト太郎</TableCell>
+          <TableCell>開発部門</TableCell>
+          <TableCell>test@example.com</TableCell>
+          <TableCell>2025/11/11</TableCell>
+          <TableCell>有効</TableCell>
+        </TableEditableRow>
+      </TableBody>
+    </Table>
+  );
+};
+
+export const Editable = EditableTemplate.bind({});
 
 const LoadingTemplate: StoryFn = () => (
   <Table loading>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, type ReactNode } from 'react';
 
 import { cn } from '../../utils';
 import { ProgressIndicator } from '../ProgressIndicator';
@@ -126,7 +126,7 @@ const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
             >
               <div
                 className="top-0 absolute flex h-full w-max -translate-x-1/2
-                  transform items-center"
+                  items-center"
               >
                 {loadingText}
               </div>
@@ -169,6 +169,48 @@ const TableRow = React.forwardRef<
   />
 ));
 TableRow.displayName = 'TableRow';
+
+interface TableEditableRowProps
+  extends React.HTMLAttributes<HTMLTableRowElement> {
+  actionComponent: ReactNode;
+}
+
+const TableEditableRow = React.forwardRef<
+  HTMLTableRowElement,
+  TableEditableRowProps
+>(({ className, children, actionComponent, ...props }, ref) => {
+  const [isShowEditRow, setIsShowEditRow] = useState(false);
+
+  const handleOnMouseOver = () => {
+    setIsShowEditRow(true);
+  };
+  const handleOnMouseLeave = () => {
+    setIsShowEditRow(false);
+  };
+
+  return (
+    <TableRow
+      ref={ref}
+      onMouseOver={handleOnMouseOver}
+      onMouseLeave={handleOnMouseLeave}
+      {...props}
+    >
+      {children}
+      {isShowEditRow ? (
+        <td
+          className="top-0 right-0 left-0 bottom-0 bg-surface-scrimmed p-sm
+            absolute"
+        >
+          <div className="gap-1 flex h-full items-center justify-end">
+            {actionComponent}
+          </div>
+        </td>
+      ) : null}
+    </TableRow>
+  );
+});
+
+TableEditableRow.displayName = 'TableEditableRow';
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
@@ -286,6 +328,7 @@ export {
   TableFooter,
   TableHead,
   TableRow,
+  TableEditableRow,
   TableCell,
   TableCaption,
   TableHeadSortButton,


### PR DESCRIPTION
## issue information
related: https://www.notion.so/Security-Settings-29c68a0d1d7a8045a1cbd9c13e2145bb
<!--
* githubのissueタイトルとURL
* slackでのコミュニケーションログ
* Notionでの関連ドキュメントリンクなど
-->

## Overview
I asked it to designer and they said it will be used in v2 application.
https://www.figma.com/design/f46iSbgpNKClOOIDRfG7AB?node-id=20105-188407&m=dev#1527272708

so I added TableEditableRow component.
<img width="936" height="108" alt="スクリーンショット 2025-12-06 19 24 46" src="https://github.com/user-attachments/assets/9aa4bbb2-5e24-4f51-99b5-8a47b673d58b" />

<!--
* 変更の理由や内容の説明
-->
## Dependencies
<!--
* 変更の影響を受けると考えられる機能や環境
-->

## Step to test
<!--
* 動作確認手順
-->

## Additional information
<!--
* 特にレビューしてほしいポイントなどの補足情報
-->
