### PR TITLE
Add row overlay component to table

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from '../StatusIndicator/StatusIndicator';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { Tag } from '../Tag';
+import { Button } from '../Button';
 
 import {
   Table,
@@ -18,6 +19,7 @@ import {
   TableCell,
   TableHeadSortButton,
 } from './Table';
+import { TableRowOverlay } from './TableRowOverlay';
 
 type DataEntry = {
   sdsName: string;
@@ -523,3 +525,221 @@ const LoadingTemplate: StoryFn = () => (
 );
 
 export const Loading = LoadingTemplate.bind({});
+
+const RowOverlayTemplate: StoryFn = () => {
+  const [openRowId, setOpenRowId] = React.useState<string | null>(null);
+  const [sortOrders, setSortOrders] = React.useState<{
+    [key: string]: 'asc' | 'desc' | undefined;
+  }>({
+    pdfUploadDate: undefined,
+    sdsRevisionDate: undefined,
+    supplierConfirmDate: undefined,
+    riskAssessmentDate: undefined,
+  });
+
+  const toggleSort = (column: string) => {
+    setSortOrders((prev) => ({
+      ...prev,
+      [column]:
+        prev[column] === 'asc'
+          ? 'desc'
+          : prev[column] === 'desc'
+            ? undefined
+            : 'asc',
+    }));
+  };
+
+  const sortedData = React.useMemo(() => {
+    const sorted = [...data];
+
+    if (sortOrders.pdfUploadDate) {
+      sorted.sort((a, b) => {
+        const compare = a.pdfUploadDate.localeCompare(b.pdfUploadDate);
+        return sortOrders.pdfUploadDate === 'asc' ? compare : -compare;
+      });
+    } else if (sortOrders.sdsRevisionDate) {
+      sorted.sort((a, b) => {
+        const compare = a.sdsRevisionDate.localeCompare(b.sdsRevisionDate);
+        return sortOrders.sdsRevisionDate === 'asc' ? compare : -compare;
+      });
+    } else if (sortOrders.supplierConfirmDate) {
+      sorted.sort((a, b) => {
+        const compare = a.supplierConfirmDate.localeCompare(
+          b.supplierConfirmDate
+        );
+        return sortOrders.supplierConfirmDate === 'asc' ? compare : -compare;
+      });
+    } else if (sortOrders.riskAssessmentDate) {
+      sorted.sort((a, b) => {
+        const compare = a.riskAssessmentDate.localeCompare(
+          b.riskAssessmentDate
+        );
+        return sortOrders.riskAssessmentDate === 'asc' ? compare : -compare;
+      });
+    }
+
+    return sorted;
+  }, [sortOrders]);
+
+  return (
+    <div className="overflow-x-auto">
+      <Table className="w-max">
+        <TableHeader>
+          <TableRow>
+            <TableHead>
+              <Checkbox label="" />
+            </TableHead>
+            <TableHead>SDSファイル名</TableHead>
+            <TableHead>製品名</TableHead>
+            <TableHead>製造者</TableHead>
+            <TableHead>データ化ステータス</TableHead>
+            <TableHead>
+              PDFアップロード日{' '}
+              <TableHeadSortButton
+                sortOrder={sortOrders.pdfUploadDate}
+                onClick={() => toggleSort('pdfUploadDate')}
+              />
+            </TableHead>
+            <TableHead>担当ユーザー</TableHead>
+            <TableHead>
+              SDS改訂日{' '}
+              <TableHeadSortButton
+                sortOrder={sortOrders.sdsRevisionDate}
+                onClick={() => toggleSort('sdsRevisionDate')}
+              />
+            </TableHead>
+            <TableHead>
+              サプライヤーへの確認日{' '}
+              <TableHeadSortButton
+                sortOrder={sortOrders.supplierConfirmDate}
+                onClick={() => toggleSort('supplierConfirmDate')}
+              />
+            </TableHead>
+            <TableHead>改訂ステータス</TableHead>
+            <TableHead>担当部署</TableHead>
+            <TableHead>タグ</TableHead>
+            <TableHead>製品コード</TableHead>
+            <TableHead>
+              リスクアセスメント実施日{' '}
+              <TableHeadSortButton
+                sortOrder={sortOrders.riskAssessmentDate}
+                onClick={() => toggleSort('riskAssessmentDate')}
+              />
+            </TableHead>
+            <TableHead>CREATE SIMPLEを出力</TableHead>
+            {/* Empty header for overlay column alignment */}
+            <TableHead className="w-0 p-0" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sortedData.map((row, index) => (
+            <TableRow key={index}>
+              <TableCell>
+                <Checkbox label="" />
+              </TableCell>
+              <TableCell>
+                <div className="gap-2 inline-flex items-center">
+                  <div className="gap-1 flex items-center">{row.sdsName}</div>
+                  <a href="#">
+                    <IconExternalLink
+                      size={20}
+                      className="text-shape-primary"
+                    />
+                  </a>
+                </div>
+              </TableCell>
+              <TableCell>
+                <Tag className="uppercase">{row.productName}</Tag>
+              </TableCell>
+              <TableCell>{row.manufacturer}</TableCell>
+              <TableCell>
+                <StatusIndicator level={row.dataStatusLevel}>
+                  {row.dataStatus}
+                </StatusIndicator>
+              </TableCell>
+              <TableCell>{row.pdfUploadDate}</TableCell>
+              <TableCell>
+                <Tag>{row.assignedUser}</Tag>
+              </TableCell>
+              <TableCell>{row.sdsRevisionDate}</TableCell>
+              <TableCell>{row.supplierConfirmDate}</TableCell>
+              <TableCell>
+                <StatusIndicator level={row.revisionStatusLevel}>
+                  {row.revisionStatus}
+                </StatusIndicator>
+              </TableCell>
+              <TableCell>
+                <div className="gap-xs flex flex-wrap">
+                  {row.departments.map((dept, i) => (
+                    <Tag key={i}>{dept}</Tag>
+                  ))}
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="gap-xs flex flex-wrap">
+                  {row.tags.map((tag, i) => (
+                    <Tag key={i} colorCode={tag.colorCode}>
+                      {tag.label}
+                    </Tag>
+                  ))}
+                </div>
+              </TableCell>
+              <TableCell>
+                <div className="gap-xs flex flex-wrap">
+                  {row.productCodes.map((code, i) => (
+                    <Tag key={i}>{code}</Tag>
+                  ))}
+                </div>
+              </TableCell>
+              <TableCell>{row.riskAssessmentDate}</TableCell>
+              <TableCell>
+                <div className="gap-1 flex items-center">
+                  <button
+                    title="Export v3.1.1"
+                    className="text-body-primary flex cursor-pointer
+                      items-center"
+                  >
+                    <IconFileCheck size={16} className="shrink-0" />
+                  </button>
+                  <span className="text-md text-body-primary font-normal">
+                    v3.1.1
+                  </span>
+                </div>
+              </TableCell>
+              <TableRowOverlay forceVisible={openRowId === row.sdsName}>
+                <Button
+                  size="sm"
+                  intent="primary"
+                  onClick={() => alert(`Edit ${row.productName}`)}
+                >
+                  Edit
+                </Button>
+                <Button
+                  size="sm"
+                  intent="secondary"
+                  onClick={() =>
+                    setOpenRowId(openRowId === row.sdsName ? null : row.sdsName)
+                  }
+                >
+                  {openRowId === row.sdsName ? 'Close' : 'More'}
+                </Button>
+              </TableRowOverlay>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export const WithRowOverlay = RowOverlayTemplate.bind({});
+WithRowOverlay.parameters = {
+  docs: {
+    description: {
+      story:
+        'Demonstrates the TableRowOverlay component that appears on row hover. ' +
+        'The overlay sticks to the right edge during horizontal scroll and can be ' +
+        'forced visible (e.g., when a dropdown is open).',
+    },
+  },
+};

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -161,8 +161,8 @@ const TableRow = React.forwardRef<
     ref={ref}
     className={cn(
       `border-surface-default [thead_&]:h-10 h-12
-      [tbody_&]:hover:bg-interactive-neutral-hover transition-colors
-      [:not(:last-child)]:border-b`,
+      [tbody_&]:hover:bg-interactive-neutral-hover group relative
+      transition-colors [:not(:last-child)]:border-b`,
       className
     )}
     {...props}

--- a/src/components/Table/TableRowOverlay.tsx
+++ b/src/components/Table/TableRowOverlay.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import { cn } from '../../utils';
+
+export interface TableRowOverlayProps {
+  /** Keep overlay visible (e.g., when dropdown is open) */
+  forceVisible?: boolean;
+  /** Additional class names for the overlay container */
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * A table row overlay that:
+ * - Sticks to the right edge during horizontal scroll
+ * - Appears on row hover or when forceVisible is true
+ * - Spans over multiple columns (not constrained to cell width)
+ *
+ * Must be used as the last child in a TableRow.
+ * Requires TableRow to have `position: relative`.
+ */
+const TableRowOverlay = React.forwardRef<
+  HTMLTableCellElement,
+  TableRowOverlayProps
+>(({ forceVisible = false, className, children }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      // Zero-width anchor cell that sticks to right
+      'right-0 w-0 p-0 sticky border-none',
+      // No background on the cell itself
+      'bg-transparent'
+    )}
+  >
+    {/* Absolutely positioned overlay relative to the row */}
+    <div
+      className={cn(
+        // Position at right edge of row, vertically centered
+        'right-0 top-0 bottom-0 absolute flex items-center',
+        // Padding for content spacing, max-content width
+        'pr-md pl-16 w-max',
+        // Z-index above other cells
+        'z-slight',
+        // Visibility control
+        forceVisible
+          ? 'opacity-100'
+          : 'opacity-0 transition-opacity group-hover:opacity-100',
+        className
+      )}
+      style={{
+        background:
+          'linear-gradient(to right, transparent 0rem, var(--token-color-background-interactive-neutral-hover) 3rem, var(--token-color-background-interactive-neutral-hover) 100%)',
+      }}
+    >
+      <div className="gap-xs flex items-center">{children}</div>
+    </div>
+  </td>
+));
+
+TableRowOverlay.displayName = 'TableRowOverlay';
+
+export { TableRowOverlay };

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -1,1 +1,2 @@
 export * from './Table';
+export * from './TableRowOverlay';


### PR DESCRIPTION
## issue information
This PR adds a new <TableRowOverlay /> to the table component with which hover actions can be built.
<img width="1235" height="272" alt="image" src="https://github.com/user-attachments/assets/eb0f6c06-8760-446e-a862-b39938ac268e" />

## Overview
- Adds new component and updates exports and storybook story

## Dependencies
None

## Step to test
You can check the new storybook story.

## Additional information
This functionality is required in multiple tables in SDS manager V2, so I decided to make it part of the component library.