### PR TITLE
feat(datasheet): Add spaicing varient for DataSheet KeyValue sub component

### DIFF
--- a/src/components/DataSheet/DataSheet.stories.tsx
+++ b/src/components/DataSheet/DataSheet.stories.tsx
@@ -51,6 +51,40 @@ export const HorizontalKeyValue: Story = () => (
   </DataSheet>
 );
 
+export const CompactKeyValue: Story = () => (
+  <DataSheet className="w-140">
+    <DataSheet.Section>
+      <DataSheet.KeyValue spacing="compact" label="SDSファイル名">
+        4-AMINO-2-CHLOROBENZOIC-5GR.pdf
+      </DataSheet.KeyValue>
+      <DataSheet.KeyValue spacing="compact" label="SDS改訂日">
+        2025/01/08 22:38
+      </DataSheet.KeyValue>
+    </DataSheet.Section>
+  </DataSheet>
+);
+
+export const CompactHorizontalKeyValue: Story = () => (
+  <DataSheet className="w-140">
+    <DataSheet.Section>
+      <DataSheet.KeyValue
+        spacing="compact"
+        orientation="horizontal"
+        label="推奨用途"
+      >
+        -
+      </DataSheet.KeyValue>
+      <DataSheet.KeyValue
+        spacing="compact"
+        orientation="horizontal"
+        label="使用上の制限"
+      >
+        -
+      </DataSheet.KeyValue>
+    </DataSheet.Section>
+  </DataSheet>
+);
+
 export const MixedLayout: Story = () => (
   <DataSheet className="w-140">
     <DataSheet.Section>
@@ -397,38 +431,4 @@ export const SectionDataExampleWithinAccordion: Story = () => (
       </Accordion.Item>
     </Accordion>
   </div>
-);
-
-export const CompactKeyValue: Story = () => (
-  <DataSheet className="w-140">
-    <DataSheet.Section className="divide-y-0">
-      <DataSheet.KeyValue variant="compact" label="SDSファイル名">
-        4-AMINO-2-CHLOROBENZOIC-5GR.pdf
-      </DataSheet.KeyValue>
-      <DataSheet.KeyValue variant="compact" label="SDS改訂日">
-        2025/01/08 22:38
-      </DataSheet.KeyValue>
-    </DataSheet.Section>
-  </DataSheet>
-);
-
-export const CompactHorizontalKeyValue: Story = () => (
-  <DataSheet className="w-140">
-    <DataSheet.Section className="divide-y-0">
-      <DataSheet.KeyValue
-        variant="compact"
-        orientation="horizontal"
-        label="推奨用途"
-      >
-        -
-      </DataSheet.KeyValue>
-      <DataSheet.KeyValue
-        variant="compact"
-        orientation="horizontal"
-        label="使用上の制限"
-      >
-        -
-      </DataSheet.KeyValue>
-    </DataSheet.Section>
-  </DataSheet>
 );

--- a/src/components/DataSheet/DataSheet.tsx
+++ b/src/components/DataSheet/DataSheet.tsx
@@ -103,32 +103,20 @@ const DataSheetSection = React.forwardRef<HTMLElement, DataSheetSectionProps>(
 );
 DataSheetSection.displayName = 'DataSheetSection';
 
-const dataSheetKeyValueVariants = cva('', {
+const dataSheetKeyValueVariants = cva('py-sm', {
   variants: {
     orientation: {
       vertical: 'gap-xxs flex flex-col',
-      horizontal: 'px-0 flex items-center',
+      horizontal: 'px-0 py-0 min-h-11 flex items-center',
     },
-    variant: {
-      default: 'py-sm',
-      compact: 'py-xxs',
+    spacing: {
+      default: '',
+      compact: 'py-xxs min-h-0 border-none',
     },
   },
-  compoundVariants: [
-    {
-      orientation: 'horizontal',
-      variant: 'default',
-      className: 'py-0 min-h-11',
-    },
-    {
-      orientation: 'horizontal',
-      variant: 'compact',
-      className: 'py-xxs',
-    },
-  ],
   defaultVariants: {
     orientation: 'vertical',
-    variant: 'default',
+    spacing: 'default',
   },
 });
 
@@ -171,11 +159,11 @@ export interface DataSheetKeyValueProps
 const DataSheetKeyValue = React.forwardRef<
   HTMLDivElement,
   DataSheetKeyValueProps
->(({ className, label, orientation, variant, children, ...props }, ref) => (
+>(({ className, label, orientation, spacing, children, ...props }, ref) => (
   <div
     ref={ref}
     className={cn(
-      dataSheetKeyValueVariants({ orientation, variant }),
+      dataSheetKeyValueVariants({ orientation, spacing }),
       className
     )}
     {...props}


### PR DESCRIPTION
## issue information
<!--
* githubのissueタイトルとURL
* slackでのコミュニケーションログ
* Notionでの関連ドキュメントリンクなど
-->

## Overview
Based on this comment
https://github.com/GoodMoneyger/sds_scan_general/pull/1736#discussion_r2635278041
This PR add the `spacing=compact` varient for the KeyValue subcompoent for Datasheet Component
<!--
* 変更の理由や内容の説明
-->
## Dependencies
<!--
* 変更の影響を受けると考えられる機能や環境
-->

## Step to test
<!--
* 動作確認手順
-->

## Additional information
<!--
* 特にレビューしてほしいポイントなどの補足情報
-->
