### PR TITLE
feat(calendar): Add locale support and improve calendar navigation UI

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,21 +1,9 @@
 import React from 'react';
 import { DayPicker, getDefaultClassNames } from 'react-day-picker';
 import 'react-day-picker/style.css';
-import { ja } from 'react-day-picker/locale';
+import { ja, enUS } from 'react-day-picker/locale';
 
 import { cn } from '../../lib/utils';
-
-// Custom locale: Japanese month/year formatting with English weekdays
-const customLocale = {
-  ...ja,
-  localize: {
-    ...ja.localize,
-    day: (n: number) => {
-      const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-      return days[n] || '';
-    },
-  },
-};
 
 // Component styles
 const getCalendarStyles = (inline: boolean) =>
@@ -66,10 +54,6 @@ export interface CalendarProps
    */
   fixedWeeks?: boolean;
   /**
-   * Whether to enable animations.
-   */
-  animate?: boolean;
-  /**
    * The month to display by default.
    */
   defaultMonth?: Date;
@@ -78,6 +62,12 @@ export interface CalendarProps
    * When inline=true, no shadow is applied. When inline=false (default), shadow is applied for overlay usage.
    */
   inline?: boolean;
+  /**
+   * The locale for date picker localization.
+   * Defaults to 'ja' (Japanese).
+   * Supported values: 'ja', 'en'
+   */
+  locale?: 'ja' | 'en';
 }
 
 // Utility functions
@@ -102,9 +92,9 @@ export const Calendar = React.forwardRef<HTMLDivElement, CalendarProps>(
       className,
       showOutsideDays = true,
       fixedWeeks = true,
-      animate = true,
       defaultMonth,
       inline = false,
+      locale = 'ja',
       ...props
     },
     ref
@@ -150,11 +140,17 @@ export const Calendar = React.forwardRef<HTMLDivElement, CalendarProps>(
         {...props}
       >
         <DayPicker
-          animate={animate}
+          animate={false}
           mode="single"
           selected={selectedDate || undefined}
           onSelect={handleDateChange}
-          locale={customLocale}
+          locale={locale === 'ja' ? ja : enUS}
+          captionLayout="dropdown"
+          navLayout="after"
+          formatters={{
+            formatYearDropdown: (year: Date) =>
+              `${year.getFullYear()}${locale === 'ja' ? '年' : ''}`,
+          }}
           disabled={
             !isValidDateRange
               ? [
@@ -184,14 +180,26 @@ export const Calendar = React.forwardRef<HTMLDivElement, CalendarProps>(
               // Root container
               root: `${defaultClassNames.root} shadow-none gap-2.5 ![--rdp-nav-height:20px] ![--rdp-nav-button-width:20px] ![--rdp-nav-button-height:20px]`,
 
-              // Header elements
-              month_caption: `text-base font-bold text-body-primary px-xxs mb-md`,
+              // Month wrapper - CSS Grid with 2 columns for header row
+              month: `grid grid-cols-[1fr_auto] auto-rows-auto`,
+
+              // Header elements - dropdowns on left (col 1, row 1)
+              month_caption: `col-start-1 row-start-1 px-xxs mb-md flex items-center`,
+              caption_label: `hidden`,
+              dropdowns: `flex gap-xxs items-center`,
+              dropdown: `border border-shape-interactive-neutral-default rounded-xs px-xs pr-xxs py-xxs gap-xxxs flex items-center text-lg font-bold text-body-primary cursor-pointer hover:border-shape-interactive-neutral-hover focus:outline-none focus:ring-2 focus:ring-interactive-focused transition-colors disabled:opacity-50 disabled:cursor-not-allowed`,
+              dropdown_root: `relative`,
+
+              // Navigation - on right (col 2, row 1)
+              nav: `col-start-2 row-start-1 flex gap-xs items-center px-xxs mb-md`,
+
+              // Calendar grid below (spans both columns, row 2)
+              month_grid: `col-span-2 row-start-2`,
+
               weekdays: `mb-xs`,
               weekday: `text-body-secondary text-[13px] font-normal leading-5 tracking-normal text-center`,
-
-              // Navigation
-              button_previous: navigationButton,
-              button_next: navigationButton,
+              button_previous: `${navigationButton} flex items-center justify-center`,
+              button_next: `${navigationButton} flex items-center justify-center`,
               chevron: `fill-current text-interactive-primary-default w-5 h-5`,
 
               // Day states

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -48,6 +48,12 @@ const meta: Meta<typeof DatePicker> = {
       description: 'Whether the popover should be open by default',
       defaultValue: false,
     },
+    locale: {
+      control: 'select',
+      options: ['ja', 'en'],
+      description: 'The locale for date picker localization',
+      defaultValue: 'ja',
+    },
   },
 };
 
@@ -148,6 +154,33 @@ export const CustomFormatting: Story = {
       </div>
     );
   },
+};
+
+// Locale Examples - demonstrates Japanese and English locales
+export const Locales: Story = {
+  render: () => (
+    <div className="space-y-6">
+      <div className="gap-6 flex items-start">
+        <div className="w-24 flex-shrink-0">
+          <h3 className="text-sm font-medium text-body-primary">Japanese</h3>
+          <h4 className="text-sm text-body-secondary">日本語</h4>
+        </div>
+        <div className="flex-1">
+          <DatePicker locale="ja" placeholder="選択してください" />
+        </div>
+      </div>
+
+      <div className="gap-6 flex items-start">
+        <div className="w-24 flex-shrink-0">
+          <h3 className="text-sm font-medium text-body-primary">English</h3>
+          <h4 className="text-sm text-body-secondary">英語</h4>
+        </div>
+        <div className="flex-1">
+          <DatePicker locale="en" placeholder="Select a date" />
+        </div>
+      </div>
+    </div>
+  ),
 };
 
 // ReactNode Placeholder Examples - showcasing the ReactNode conversion functionality

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -83,6 +83,12 @@ export interface DatePickerProps
    * Which side to display the calendar relative to the input.
    */
   side?: 'top' | 'right' | 'bottom' | 'left';
+  /**
+   * The locale for date picker localization.
+   * Defaults to 'ja' (Japanese).
+   * Supported values: 'ja', 'en'
+   */
+  locale?: 'ja' | 'en';
 }
 
 // Utility functions
@@ -123,6 +129,7 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       open,
       onOpenChange,
       side = 'bottom',
+      locale = 'ja',
     },
     ref
   ) => {
@@ -249,8 +256,8 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
               disabled={!isValidDateRange}
               showOutsideDays={true}
               fixedWeeks={true}
-              animate={true}
               defaultMonth={selectedDate || new Date()}
+              locale={locale}
             />
           </Popover.Content>
         </Popover.Portal>


### PR DESCRIPTION
## issue information
https://www.notion.so/Update-DatePicker-component-to-allow-direct-selection-of-month-and-year-2c468a0d1d7a80209e0ec9787e802845
<!--
* githubのissueタイトルとURL
* slackでのコミュニケーションログ
* Notionでの関連ドキュメントリンクなど
-->

## Overview
This PR update date picker to be able to pick year and month via dropdown
**Note**
The locale was hard coded to be japanese so i made some additional changes to pass in either jp or en (default to jp)
I removed animate prop:  animate set to `true` make the year field flcker to its default value for a spit second, when changing months via navigation. 

styling was handled by cluade (i am not good at css yet so may be stlying part could be improved)

<!--
* 変更の理由や内容の説明
-->
## Dependencies
<!--
* 変更の影響を受けると考えられる機能や環境
-->

## Step to test
<!--
* 動作確認手順
-->

## Additional information
<!--
* 特にレビューしてほしいポイントなどの補足情報
-->
