### PR TITLE
fix(TabBar): Correct tab bar state to avoid shift when disabled

### DIFF
--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -31,21 +31,21 @@ const tabBarVariants = cva('inline-flex', {
 
 // Individual Tab variants
 const tabVariants = cva(
-  `text-body-primary border-divider-default hover:border-interactive-hover
-  data-[state=active]:border-interactive-selected data-[state=active]:font-bold
-  disabled:text-interactive-disabled disabled:hover:border-divider-default
-  relative inline-flex cursor-pointer items-center justify-center border-b pb-px
-  leading-[100%] tracking-[0] transition-colors hover:border-b-2
-  disabled:cursor-not-allowed disabled:hover:border-b
-  data-[state=active]:border-b-2
-  data-[state=active]:text-[var(--chemican-green-800)]`,
+  `text-body-primary border-divider-default data-[state=active]:font-bold
+  disabled:text-interactive-disabled after:left-0 after:h-0
+  disabled:hover:after:h-0 relative inline-flex cursor-pointer items-center
+  justify-center border-b leading-[100%] tracking-[0] transition-colors
+  after:absolute after:bottom-[-1px] after:w-full after:transition-all
+  after:content-[''] hover:after:h-[2px]
+  hover:after:bg-[var(--chemican-green-800)] disabled:cursor-not-allowed
+  data-[state=active]:text-[var(--chemican-green-800)]
+  data-[state=active]:after:h-[2px]
+  data-[state=active]:after:bg-[var(--chemican-green-800)]`,
   {
     variants: {
       size: {
-        normal: `p-md h-12 text-lg hover:pb-[calc(1rem-1px)]
-        data-[state=active]:pb-[calc(1rem-1px)]`,
-        small: `p-sm h-9.5 text-md hover:pb-[calc(0.75rem-1px)]
-        data-[state=active]:pb-[calc(0.75rem-1px)]`,
+        normal: 'p-md h-12 text-lg',
+        small: 'p-sm h-9.5 text-md',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## issue information
Change the way the state for hover and active is made to avoid the current shift for disabled.
before we were changing the spacing, but I believe it was not resilient to future changes and variant.

## Note
I noticed the disabled cursor was not working as expected so I solved it as well.

## Before change

https://github.com/user-attachments/assets/fc483e10-f7d5-4520-b7fb-d727fa203c63

## After change

https://github.com/user-attachments/assets/f9cc3584-3c86-465e-bff8-990973fb9867


