### PR TITLE
Add onClose hook to Dialog components (+ small consistency updates)

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -122,3 +122,71 @@ WithCustomActions.args = {
     },
   ],
 };
+
+export const WithOnCancelControl: StoryFn<DialogProps> = (args) => {
+  const [isOpen, setIsOpen] = useState(args.isOpen);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(true);
+  const [result, setResult] = useState<unknown>(null);
+
+  const handleClose = (value?: unknown) => {
+    setIsOpen(false);
+    setResult(value);
+    console.log('Dialog closed with value:', value);
+  };
+
+  const handleCancel = (close: () => void) => {
+    if (hasUnsavedChanges) {
+      const confirmed = confirm(
+        'You have unsaved changes. Are you sure you want to close?'
+      );
+      if (confirmed) {
+        close();
+      }
+      // If not confirmed, don't call close() - dialog stays open
+    } else {
+      close(); // No changes, close immediately
+    }
+  };
+
+  return (
+    <>
+      <div style={{ marginBottom: '10px' }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={hasUnsavedChanges}
+            onChange={(e) => setHasUnsavedChanges(e.target.checked)}
+          />{' '}
+          Simulate unsaved changes
+        </label>
+      </div>
+      <Button intent="secondary" onClick={() => setIsOpen(true)}>
+        Open Modal
+      </Button>
+      {result && (
+        <p style={{ marginTop: '10px', color: '#666' }}>
+          Last result: {JSON.stringify(result)}
+        </p>
+      )}
+      <Dialog
+        {...args}
+        isOpen={isOpen}
+        onClose={handleClose}
+        onCancel={handleCancel}
+      />
+    </>
+  );
+};
+WithOnCancelControl.args = {
+  isOpen: false,
+  title: 'Edit Form',
+  children:
+    'This dialog demonstrates the onCancel handler. Try clicking outside, pressing Escape, or clicking Cancel with the checkbox enabled/disabled.',
+  actions: [
+    {
+      label: 'Save',
+      value: 'saved',
+      intent: 'primary',
+    },
+  ],
+};

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -18,6 +18,7 @@ export interface DialogProps
   extends React.ComponentProps<typeof RadixDialog.Root> {
   isOpen: boolean;
   onClose: (value?: unknown) => void;
+  onCancel?: (close: () => void) => void | Promise<void>;
   children: ReactNode;
   busy?: boolean;
   title: ReactNode;
@@ -38,6 +39,7 @@ const defaultActions: DialogAction[] = [
 export const Dialog: React.FC<DialogProps> = ({
   isOpen,
   onClose,
+  onCancel = (close) => close(),
   title,
   children,
   busy,
@@ -73,7 +75,24 @@ export const Dialog: React.FC<DialogProps> = ({
   };
 
   const handleCancelClick = () => {
-    onClose();
+    onCancel(onClose);
+  };
+
+  const handleOutsideClick = (e: Event) => {
+    e.preventDefault();
+    if (cancellable && !busyState && allowClickOutside) {
+      onCancel(onClose);
+    }
+  };
+
+  const handleEscapeKeyDown = (e: KeyboardEvent) => {
+    if (busyState) {
+      e.preventDefault();
+      return;
+    }
+
+    e.preventDefault();
+    onCancel(onClose);
   };
 
   return (
@@ -85,11 +104,8 @@ export const Dialog: React.FC<DialogProps> = ({
         >
           <RadixDialog.Content
             aria-describedby={undefined}
-            onPointerDownOutside={(e) => {
-              if (!allowClickOutside || busyState) {
-                e.preventDefault();
-              }
-            }}
+            onPointerDownOutside={handleOutsideClick}
+            onEscapeKeyDown={handleEscapeKeyDown}
             className="bg-surface-primary rounded-lg z-dialog max-w-screen-sm
               min-w-96 fixed top-1/2 left-1/2 flex max-h-[90vh] w-2/3
               -translate-x-1/2 -translate-y-1/2 transform flex-col
@@ -116,15 +132,13 @@ export const Dialog: React.FC<DialogProps> = ({
             </div>
             <div className="px-xl py-md flex flex-shrink-0 justify-between">
               {cancellable && (
-                <RadixDialog.Close asChild>
-                  <Button
-                    intent="tertiary"
-                    onClick={handleCancelClick}
-                    disabled={busyState}
-                  >
-                    {cancelButtonLabel}
-                  </Button>
-                </RadixDialog.Close>
+                <Button
+                  intent="tertiary"
+                  onClick={handleCancelClick}
+                  disabled={busyState}
+                >
+                  {cancelButtonLabel}
+                </Button>
               )}
               <div className={`gap-xs flex ${!cancellable ? 'ml-auto' : ''}`}>
                 {actions.map((action, index) => {

--- a/src/components/Dialog/MultiStepDialog.stories.tsx
+++ b/src/components/Dialog/MultiStepDialog.stories.tsx
@@ -306,3 +306,105 @@ const SingleStepComponent = () => {
 export const SingleStep: Story = {
   render: () => <SingleStepComponent />,
 };
+
+// With onCancel control
+const WithOnCancelControlComponent = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(true);
+
+  const handleCancel = (close: () => void) => {
+    if (hasUnsavedChanges) {
+      const confirmed = confirm(
+        'You have unsaved changes. Are you sure you want to close?'
+      );
+      if (confirmed) {
+        close();
+      }
+      // If not confirmed, don't call close() - dialog stays open
+    } else {
+      close(); // No changes, close immediately
+    }
+  };
+
+  return (
+    <>
+      <div style={{ marginBottom: '10px' }}>
+        <label>
+          <input
+            type="checkbox"
+            checked={hasUnsavedChanges}
+            onChange={(e) => setHasUnsavedChanges(e.target.checked)}
+          />{' '}
+          Simulate unsaved changes
+        </label>
+      </div>
+      <Button onClick={() => setIsOpen(true)}>Open Form</Button>
+      <MultiStepDialog.Root
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onCancel={handleCancel}
+      >
+        <MultiStepDialog.Step>
+          <MultiStepDialog.Header>Edit User Profile</MultiStepDialog.Header>
+          <MultiStepDialog.Body>
+            <div className="gap-md flex flex-col">
+              <p>
+                This dialog demonstrates the onCancel handler. Try clicking
+                outside, pressing Escape, or clicking Cancel with the checkbox
+                enabled/disabled.
+              </p>
+              <input
+                type="text"
+                placeholder="Name"
+                className="border-divider-default rounded-md px-md py-sm
+                  border-1"
+              />
+              <input
+                type="email"
+                placeholder="Email"
+                className="border-divider-default rounded-md px-md py-sm
+                  border-1"
+              />
+            </div>
+          </MultiStepDialog.Body>
+          <MultiStepDialog.Footer>
+            <MultiStepDialog.Action
+              label="次へ"
+              intent="primary"
+              onAction={({ nextStep }) => nextStep()}
+            />
+          </MultiStepDialog.Footer>
+        </MultiStepDialog.Step>
+
+        <MultiStepDialog.Step>
+          <MultiStepDialog.Header>Preferences</MultiStepDialog.Header>
+          <MultiStepDialog.Body>
+            <div className="gap-md flex flex-col">
+              <p>Configure your preferences.</p>
+              <label className="gap-sm flex items-center">
+                <input type="checkbox" />
+                <span>Email notifications</span>
+              </label>
+            </div>
+          </MultiStepDialog.Body>
+          <MultiStepDialog.Footer>
+            <MultiStepDialog.Action
+              label="戻る"
+              intent="secondary"
+              onAction={({ prevStep }) => prevStep()}
+            />
+            <MultiStepDialog.Action
+              label="Save"
+              intent="primary"
+              closeOnAction
+            />
+          </MultiStepDialog.Footer>
+        </MultiStepDialog.Step>
+      </MultiStepDialog.Root>
+    </>
+  );
+};
+
+export const WithOnCancelControl: Story = {
+  render: () => <WithOnCancelControlComponent />,
+};

--- a/src/components/Dialog/MultiStepDialog.tsx
+++ b/src/components/Dialog/MultiStepDialog.tsx
@@ -18,6 +18,9 @@ interface MultiStepDialogContextValue {
   prevStep: () => void;
   isFirstStep: boolean;
   isLastStep: boolean;
+  cancellable: boolean;
+  onClose: (value?: unknown) => void;
+  onCancel: (close: () => void) => void | Promise<void>;
 }
 
 const MultiStepDialogContext = createContext<
@@ -38,9 +41,11 @@ const useMultiStepDialog = () => {
 export interface MultiStepDialogRootProps {
   isOpen: boolean;
   onClose: (value?: unknown) => void;
+  onCancel?: (close: () => void) => void | Promise<void>;
   children: ReactNode;
   initialStep?: number;
   currentStep?: number; // Controlled mode
+  cancellable?: boolean;
   allowClickOutside?: boolean;
   onStepChange?: (step: number) => void;
 }
@@ -49,9 +54,11 @@ export interface MultiStepDialogRootProps {
 const Root: React.FC<MultiStepDialogRootProps> = ({
   isOpen,
   onClose,
+  onCancel = (close) => close(),
   children,
   initialStep = 0,
   currentStep: controlledStep,
+  cancellable = true,
   allowClickOutside = true,
   onStepChange,
 }) => {
@@ -77,6 +84,28 @@ const Root: React.FC<MultiStepDialogRootProps> = ({
   const nextStep = () => goToStep(currentStep + 1);
   const prevStep = () => goToStep(currentStep - 1);
 
+  // Reset step on close
+  const handleClose = (value?: unknown) => {
+    if (controlledStep === undefined) {
+      setInternalStep(initialStep);
+    }
+    onClose(value);
+  };
+
+  const handleOutsideClick = (e: Event) => {
+    e.preventDefault();
+    if (cancellable && allowClickOutside) {
+      onCancel(handleClose);
+    }
+  };
+
+  const handleEscapeKeyDown = (e: KeyboardEvent) => {
+    e.preventDefault();
+    if (cancellable) {
+      onCancel(handleClose);
+    }
+  };
+
   const contextValue: MultiStepDialogContextValue = {
     currentStep,
     totalSteps,
@@ -85,14 +114,9 @@ const Root: React.FC<MultiStepDialogRootProps> = ({
     prevStep,
     isFirstStep: currentStep === 0,
     isLastStep: currentStep === totalSteps - 1,
-  };
-
-  // Reset step on close
-  const handleClose = (value?: unknown) => {
-    if (controlledStep === undefined) {
-      setInternalStep(initialStep);
-    }
-    onClose(value);
+    cancellable,
+    onClose: handleClose,
+    onCancel,
   };
 
   return (
@@ -107,11 +131,8 @@ const Root: React.FC<MultiStepDialogRootProps> = ({
               className="bg-surface-primary rounded-lg z-dialog max-w-screen-sm
                 min-w-96 fixed top-1/2 left-1/2 w-2/3 -translate-x-1/2
                 -translate-y-1/2 transform overflow-auto"
-              onPointerDownOutside={(event) => {
-                if (!allowClickOutside) {
-                  event.preventDefault();
-                }
-              }}
+              onPointerDownOutside={handleOutsideClick}
+              onEscapeKeyDown={handleEscapeKeyDown}
             >
               {steps[currentStep]}
             </RadixDialog.Content>
@@ -180,17 +201,24 @@ const Footer: React.FC<MultiStepDialogFooterProps> = ({
   children,
   showCancel = true,
   cancelLabel = 'キャンセル',
-  onCancel,
+  onCancel: onCancelProp,
 }) => {
+  const { onCancel, onClose, cancellable } = useMultiStepDialog();
+
+  const handleCancelClick = () => {
+    if (onCancelProp) {
+      onCancelProp();
+    }
+    onCancel(onClose);
+  };
+
   return (
     <div className="px-xl py-md flex justify-between">
       <div className="gap-xs flex">
-        {showCancel && (
-          <RadixDialog.Close asChild>
-            <Button intent="tertiary" onClick={onCancel}>
-              {cancelLabel}
-            </Button>
-          </RadixDialog.Close>
+        {showCancel && cancellable && (
+          <Button intent="tertiary" onClick={handleCancelClick}>
+            {cancelLabel}
+          </Button>
         )}
       </div>
       {children && <div className="gap-xs ml-auto flex">{children}</div>}


### PR DESCRIPTION
## issue information
Small addition to the Dialog components to allow controlling whether outside clicks will close the dialog. This is already implemented for the multi step dialog, but not for the normal dialog yet.

## Overview
- Add allowClickOutside prop (default `true`) to control whether dialogs can be closed by clicking outside of them

## Additional information
Conventionally, dialogs/modals should be closable by outside click, unless the modal has to enforce a decision to continue a flow.
