### PR TITLE
Add allowCreate functionality to enable creating new items for select drop down and multiselect dropdown

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -71,6 +71,10 @@ const meta: Meta<typeof MultiSelect> = {
       control: 'boolean',
       description: 'Whether to filter by both value and label when searching',
     },
+    allowCreate: {
+      control: 'boolean',
+      description: 'Whether to allow creating new items',
+    },
   },
 };
 
@@ -893,6 +897,78 @@ export const InlineSelectionComparison: Story = {
   placeholder="Select fruits..."
   selectionDisplayMode="inline"
   defaultValue={['apple', 'banana', 'cherry']}
+/>`,
+      },
+    },
+  },
+};
+
+const WithAllowCreateComponent = () => {
+  const [values, setValues] = React.useState<Array<string | number>>([]);
+  const [options, setOptions] =
+    React.useState<MultiSelectOption[]>(basicOptions);
+
+  const handleCreate = (inputValue: string) => {
+    const newOption: MultiSelectOption = {
+      value: inputValue.toLowerCase().replace(/\s+/g, '-'),
+      label: inputValue,
+      isCreated: true,
+    };
+    setOptions((prev) => [newOption, ...prev]);
+    return newOption;
+  };
+
+  return (
+    <div className="w-[350px]">
+      <MultiSelect
+        options={options}
+        defaultValue={values}
+        onValueChange={setValues}
+        allowCreate
+        onCreate={handleCreate}
+        placeholder="Select or create..."
+        searchPlaceholder="Type to search or create..."
+      />
+      <p className="mt-md text-body-secondary text-sm">
+        Type a new value and press Enter to create
+      </p>
+    </div>
+  );
+};
+
+export const WithAllowCreate: Story = {
+  render: () => <WithAllowCreateComponent />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This story demonstrates the allowCreate functionality. When enabled, users can type a new value and press Enter to create a new option. Created items appear in a separate "Created Items" group with a "(created)" label.',
+      },
+      source: {
+        code: `import { MultiSelect } from '@chemican/components';
+import { useState } from 'react';
+
+const [values, setValues] = useState<string[]>([]);
+const [options, setOptions] = useState(basicOptions);
+
+const handleCreate = (inputValue: string) => {
+  const newOption = {
+    value: inputValue.toLowerCase().replace(/\\s+/g, '-'),
+    label: inputValue,
+    isCreated: true,
+  };
+  setOptions((prev) => [newOption, ...prev]);
+  return newOption;
+};
+
+<MultiSelect
+  options={options}
+  defaultValue={values}
+  onValueChange={setValues}
+  allowCreate
+  onCreate={handleCreate}
+  placeholder="Select or create..."
+  searchPlaceholder="Type to search or create..."
 />`,
       },
     },

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { IconChevronDown } from '@tabler/icons-react';
+import { IconChevronDown, IconPlus } from '@tabler/icons-react';
 
 import { cn } from '../../lib/utils';
 import { Button } from '../Button';
@@ -46,6 +46,7 @@ interface MultiSelectOption<T = string | number> {
   value: T;
   label: string;
   disabled?: boolean;
+  isCreated?: boolean;
   [key: string]: unknown;
 }
 
@@ -343,6 +344,37 @@ interface MultiSelectProps<T = string | number>
   renderOption?: (context: RenderOptionContext<T>) => React.ReactNode;
 
   /**
+   * If true, allows creating new items by typing and pressing Enter.
+   * Optional, defaults to false.
+   */
+  allowCreate?: boolean;
+
+  /**
+   * Callback fired when a new item is created.
+   * Should return the new option, or void if handled externally.
+   * If not provided, the component manages created items internally.
+   */
+  onCreate?: (inputValue: string) => MultiSelectOption<T> | void;
+
+  /**
+   * Label shown next to created items.
+   * Optional, defaults to "(created)".
+   */
+  createdLabel?: React.ReactNode;
+
+  /**
+   * Group label for created items section.
+   * Optional, defaults to "Created Items".
+   */
+  createdGroupLabel?: React.ReactNode;
+
+  /**
+   * Group label for available items section (shown when there are created items).
+   * Optional, defaults to "Available Items".
+   */
+  availableGroupLabel?: React.ReactNode;
+
+  /**
    * Callback fired when selected values change.
    * Receives the array of currently selected values.
    * Optional, called after each selection/deselection.
@@ -425,6 +457,11 @@ const MultiSelectInner = <T extends string | number = string | number>(
     customTrigger,
     selectionDisplayMode = 'default',
     hideSelection = false,
+    allowCreate = false,
+    onCreate,
+    createdLabel = '(created)',
+    createdGroupLabel = 'Created Items',
+    availableGroupLabel = 'Available Items',
     ...props
   }: MultiSelectProps<T>,
   ref: React.Ref<MultiSelectRef<T>>
@@ -432,6 +469,9 @@ const MultiSelectInner = <T extends string | number = string | number>(
   const [selectedValues, setSelectedValues] = React.useState<T[]>(defaultValue);
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
   const [searchValue, setSearchValue] = React.useState('');
+  const [createdOptions, setCreatedOptions] = React.useState<
+    MultiSelectOption<T>[]
+  >([]);
 
   const [politeMessage, setPoliteMessage] = React.useState('');
   const [assertiveMessage, setAssertiveMessage] = React.useState('');
@@ -571,13 +611,18 @@ const MultiSelectInner = <T extends string | number = string | number>(
   const responsiveSettings = getResponsiveSettings();
 
   const getAllOptions = React.useCallback((): MultiSelectOption<T>[] => {
-    if (options.length === 0) return [];
-    let allOptions: MultiSelectOption<T>[];
-    if (isGroupedOptions(options)) {
-      allOptions = options.flatMap((group) => group.options);
+    let baseOptions: MultiSelectOption<T>[];
+    if (options.length === 0) {
+      baseOptions = [];
+    } else if (isGroupedOptions(options)) {
+      baseOptions = options.flatMap((group) => group.options);
     } else {
-      allOptions = options;
+      baseOptions = options;
     }
+
+    // Include created options (either from internal state or from options with isCreated)
+    const allOptions = [...createdOptions, ...baseOptions];
+
     const valueSet = new Set<T>();
     const duplicates: T[] = [];
     const uniqueOptions: MultiSelectOption<T>[] = [];
@@ -606,7 +651,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
       );
     }
     return deduplicateOptions ? uniqueOptions : allOptions;
-  }, [options, deduplicateOptions, isGroupedOptions]);
+  }, [options, deduplicateOptions, isGroupedOptions, createdOptions]);
 
   const getOptionByValue = React.useCallback(
     (value: T): MultiSelectOption<T> | undefined => {
@@ -646,9 +691,69 @@ const MultiSelectInner = <T extends string | number = string | number>(
     [filterByValueAndLabel]
   );
 
+  const handleCreate = () => {
+    if (!allowCreate || !searchValue.trim()) return;
+
+    const trimmedValue = searchValue.trim();
+    const allOpts = getAllOptions();
+
+    // Check if value already exists
+    const exists = allOpts.some(
+      (opt) =>
+        String(opt.label).toLowerCase() === trimmedValue.toLowerCase() ||
+        String(opt.value).toLowerCase() === trimmedValue.toLowerCase()
+    );
+
+    if (exists) return;
+
+    let newOption: MultiSelectOption<T>;
+
+    if (onCreate) {
+      // Parent manages created options via onCreate callback
+      const result = onCreate(trimmedValue);
+      if (result) {
+        newOption = { ...result, isCreated: true };
+        const newSelectedValues = [...selectedValues, newOption.value];
+        setSelectedValues(newSelectedValues);
+        onValueChange(newSelectedValues);
+      }
+    } else {
+      // No onCreate provided - use internal state to track created items
+      newOption = {
+        value: trimmedValue as T,
+        label: trimmedValue,
+        isCreated: true,
+      };
+      setCreatedOptions((prev) => [newOption, ...prev]);
+      const newSelectedValues = [...selectedValues, newOption.value];
+      setSelectedValues(newSelectedValues);
+      onValueChange(newSelectedValues);
+    }
+
+    setSearchValue('');
+  };
+
+  const showCreateOption = React.useMemo(() => {
+    if (!allowCreate || !searchValue.trim()) return false;
+    const allOpts = getAllOptions();
+    return !allOpts.some(
+      (opt) =>
+        String(opt.label).toLowerCase() === searchValue.trim().toLowerCase()
+    );
+  }, [allowCreate, searchValue, getAllOptions]);
+
+  const hasCreatedItems = React.useMemo(() => {
+    return getAllOptions().some((opt) => opt.isCreated);
+  }, [getAllOptions]);
+
   const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
-      setIsPopoverOpen(true);
+      if (allowCreate && showCreateOption) {
+        event.preventDefault();
+        handleCreate();
+      } else {
+        setIsPopoverOpen(true);
+      }
     } else if (event.key === 'Backspace' && !event.currentTarget.value) {
       const newSelectedValues = [...selectedValues];
       newSelectedValues.pop();
@@ -1021,8 +1126,25 @@ const MultiSelectInner = <T extends string | number = string | number>(
               )}
               style={{ overscrollBehaviorY: 'contain' }}
             >
-              <CommandEmpty>{emptyIndicator}</CommandEmpty>
+              <CommandEmpty>
+                {showCreateOption ? null : emptyIndicator}
+              </CommandEmpty>
 
+              {/* Create new item option */}
+              {showCreateOption && (
+                <CommandGroup>
+                  <CommandItem
+                    value={`create:${searchValue}`}
+                    onSelect={handleCreate}
+                    className="text-interactive-primary-default !cursor-pointer"
+                  >
+                    <IconPlus className="h-4 w-4 mr-xs" />
+                    <span>Create &quot;{searchValue.trim()}&quot;</span>
+                  </CommandItem>
+                </CommandGroup>
+              )}
+
+              {/* Select all - at the very top */}
               {!hideSelectAll && !searchValue && (
                 <CommandGroup>
                   <CommandItem
@@ -1035,7 +1157,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
                       getAllOptions().filter((opt) => !opt.disabled).length
                     }
                     aria-label={`Select all ${getAllOptions().length} options`}
-                    className="cursor-pointer"
+                    className="!cursor-pointer"
                   >
                     <Checkbox
                       className="mr-xs"
@@ -1057,10 +1179,90 @@ const MultiSelectInner = <T extends string | number = string | number>(
                   </CommandItem>
                 </CommandGroup>
               )}
+
+              {/* Created items group */}
+              {getAllOptions().filter((opt) => opt.isCreated).length > 0 && (
+                <CommandGroup heading={createdGroupLabel as string}>
+                  {getAllOptions()
+                    .filter((opt) => opt.isCreated)
+                    .map((option) => {
+                      const isSelected = selectedValues.includes(option.value);
+                      return (
+                        <CommandItem
+                          key={option.value}
+                          value={`${option.value}:${option.label}`}
+                          onSelect={() => toggleOption(option.value)}
+                          role="option"
+                          aria-selected={isSelected}
+                          className="!cursor-pointer"
+                        >
+                          <Checkbox className="mr-xs" checked={isSelected} />
+                          <span className="flex-1">{option.label}</span>
+                          <span className="text-body-secondary text-sm">
+                            {createdLabel}
+                          </span>
+                        </CommandItem>
+                      );
+                    })}
+                </CommandGroup>
+              )}
+
               {isGroupedOptions(options) ? (
-                options.map((group) => (
-                  <CommandGroup key={group.heading} heading={group.heading}>
-                    {group.options.map((option) => {
+                <>
+                  {options.map((group) => (
+                    <CommandGroup key={group.heading} heading={group.heading}>
+                      {group.options
+                        .filter((opt) => !opt.isCreated)
+                        .map((option) => {
+                          const isSelected = selectedValues.includes(
+                            option.value
+                          );
+                          return (
+                            <CommandItem
+                              key={option.value}
+                              value={`${option.value}:${option.label}`}
+                              onSelect={() => toggleOption(option.value)}
+                              role="option"
+                              aria-selected={isSelected}
+                              aria-disabled={option.disabled ?? false}
+                              aria-label={`${option.label}${
+                                isSelected ? ', selected' : ', not selected'
+                              }${option.disabled ? ', disabled' : ''}`}
+                              className={cn(
+                                '!cursor-pointer',
+                                option.disabled &&
+                                  `text-interactive-disabled !cursor-not-allowed
+                                    opacity-100
+                                    data-[disabled=true]:opacity-100`
+                              )}
+                              disabled={Boolean(option.disabled)}
+                            >
+                              <Checkbox
+                                className="mr-xs"
+                                checked={isSelected}
+                              />
+                              {effectiveRenderOption({
+                                option,
+                                location: 'dropdown',
+                                isSelected,
+                              })}
+                            </CommandItem>
+                          );
+                        })}
+                    </CommandGroup>
+                  ))}
+                </>
+              ) : (
+                <CommandGroup
+                  heading={
+                    hasCreatedItems
+                      ? (availableGroupLabel as string)
+                      : undefined
+                  }
+                >
+                  {(options as MultiSelectOption<T>[])
+                    .filter((opt) => !opt.isCreated)
+                    .map((option) => {
                       const isSelected = selectedValues.includes(option.value);
                       return (
                         <CommandItem
@@ -1074,9 +1276,9 @@ const MultiSelectInner = <T extends string | number = string | number>(
                             isSelected ? ', selected' : ', not selected'
                           }${option.disabled ? ', disabled' : ''}`}
                           className={cn(
-                            'cursor-pointer',
+                            '!cursor-pointer',
                             option.disabled &&
-                              `text-interactive-disabled cursor-not-allowed
+                              `text-interactive-disabled !cursor-not-allowed
                                 opacity-100 data-[disabled=true]:opacity-100`
                           )}
                           disabled={Boolean(option.disabled)}
@@ -1090,40 +1292,6 @@ const MultiSelectInner = <T extends string | number = string | number>(
                         </CommandItem>
                       );
                     })}
-                  </CommandGroup>
-                ))
-              ) : (
-                <CommandGroup>
-                  {options.map((option) => {
-                    const isSelected = selectedValues.includes(option.value);
-                    return (
-                      <CommandItem
-                        key={option.value}
-                        value={`${option.value}:${option.label}`}
-                        onSelect={() => toggleOption(option.value)}
-                        role="option"
-                        aria-selected={isSelected}
-                        aria-disabled={option.disabled ?? false}
-                        aria-label={`${option.label}${
-                          isSelected ? ', selected' : ', not selected'
-                        }${option.disabled ? ', disabled' : ''}`}
-                        className={cn(
-                          'cursor-pointer',
-                          option.disabled &&
-                            `text-interactive-disabled cursor-not-allowed
-                              opacity-100 data-[disabled=true]:opacity-100`
-                        )}
-                        disabled={Boolean(option.disabled)}
-                      >
-                        <Checkbox className="mr-xs" checked={isSelected} />
-                        {effectiveRenderOption({
-                          option,
-                          location: 'dropdown',
-                          isSelected,
-                        })}
-                      </CommandItem>
-                    );
-                  })}
                 </CommandGroup>
               )}
             </CommandList>

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -31,6 +31,12 @@ const meta: Meta<typeof Select> = {
     invalid: {
       control: { type: 'boolean' },
     },
+    searchable: {
+      control: { type: 'boolean' },
+    },
+    allowCreate: {
+      control: { type: 'boolean' },
+    },
   },
   parameters: {
     radixDocs: {
@@ -242,3 +248,69 @@ export const IsolatedVsFormField: StoryFn = () => (
     </div>
   </div>
 );
+
+export const WithSearch: StoryFn<SelectProps> = () => {
+  const [value, setValue] = React.useState<string | undefined>(undefined);
+
+  return (
+    <div className="w-[300px]">
+      <Select
+        options={[
+          { value: 'apple', label: 'Apple' },
+          { value: 'banana', label: 'Banana' },
+          { value: 'cherry', label: 'Cherry' },
+          { value: 'date', label: 'Date' },
+          { value: 'elderberry', label: 'Elderberry' },
+          { value: 'fig', label: 'Fig' },
+          { value: 'grape', label: 'Grape' },
+        ]}
+        value={value}
+        onValueChange={setValue}
+        searchable
+        placeholder="Search fruits..."
+        searchPlaceholder="Type to search..."
+      />
+      <p className="mt-md text-body-secondary text-sm">
+        Select with search enabled
+      </p>
+    </div>
+  );
+};
+WithSearch.storyName = 'With Search';
+
+export const WithAllowCreate: StoryFn<SelectProps> = () => {
+  const [value, setValue] = React.useState<string | undefined>(undefined);
+  const [options, setOptions] = React.useState([
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+  ]);
+
+  const handleCreate = (inputValue: string) => {
+    const newOption = {
+      value: inputValue.toLowerCase().replace(/\s+/g, '-'),
+      label: inputValue,
+      isCreated: true,
+    };
+    setOptions((prev) => [newOption, ...prev]);
+    return newOption;
+  };
+
+  return (
+    <div className="w-[300px]">
+      <Select
+        options={options}
+        value={value}
+        onValueChange={setValue}
+        allowCreate
+        onCreate={handleCreate}
+        placeholder="Select or create"
+        searchPlaceholder="Type to search or create..."
+      />
+      <p className="mt-md text-body-secondary text-sm">
+        Type a new value and press Enter to create
+      </p>
+    </div>
+  );
+};
+WithAllowCreate.storyName = 'With Allow Create';

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,19 +1,29 @@
 import React from 'react';
-import { Select as RadixSelect } from 'radix-ui';
-import { IconChevronDown } from '@tabler/icons-react';
+import { IconChevronDown, IconPlus } from '@tabler/icons-react';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 
 import type { IconProp } from '../../lib/utils';
 import { cn, renderIcon } from '../../lib/utils';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '../../lib/components/Popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '../../lib/components/Command';
 
 const selectVariants = cva(
   `bg-surface-primary text-body-primary disabled:border-interactive-disabled
-  disabled:bg-surface-disabled disabled:text-body-disabled
-  [&[data-placeholder]]:text-body-placeholder
-  disabled:[&[data-placeholder]]:text-body-disabled inline-flex items-center
-  justify-between border focus-visible:ring-4 focus-visible:outline-none
-  enabled:cursor-pointer data-[state=open]:ring-4`,
+  disabled:bg-surface-disabled disabled:text-body-disabled inline-flex
+  items-center justify-between border focus-visible:ring-4
+  focus-visible:outline-none enabled:cursor-pointer data-[state=open]:ring-4`,
   {
     variants: {
       variant: {
@@ -50,8 +60,8 @@ const selectVariants = cva(
 );
 
 const selectContentVariants = cva(
-  `bg-surface-primary z-dropdown relative -mt-px -mb-px w-full min-w-[8rem]
-  overflow-hidden border`,
+  `bg-surface-primary z-dropdown relative w-full min-w-[8rem] overflow-hidden
+  border`,
   {
     variants: {
       variant: {
@@ -67,10 +77,8 @@ const selectContentVariants = cva(
 );
 
 const selectItemVariants = cva(
-  `disabled:bg-surface-disabled disabled:text-interactive-disabled
-  data-[disabled]:text-interactive-disabled flex cursor-pointer items-center
-  border-0 ring-0 focus:outline-0 disabled:cursor-not-allowed
-  data-[disabled]:cursor-not-allowed`,
+  `flex !cursor-pointer items-center border-0 ring-0 focus:outline-0
+  data-[disabled=true]:!cursor-not-allowed data-[disabled=true]:opacity-50`,
   {
     variants: {
       variant: {
@@ -99,16 +107,17 @@ const selectItemVariants = cva(
   }
 );
 
-export interface SelectProps
-  extends VariantProps<typeof selectVariants>,
-    Omit<React.ComponentProps<typeof RadixSelect.Root>, 'value'> {
-  options: {
-    value: string;
-    label: React.ReactNode;
-    icon?: IconProp;
-    type?: 'Option' | 'Group' | 'Separator';
-    disabled?: boolean;
-  }[];
+export interface SelectOption {
+  value: string;
+  label: React.ReactNode;
+  icon?: IconProp;
+  type?: 'Option' | 'Group' | 'Separator';
+  disabled?: boolean;
+  isCreated?: boolean;
+}
+
+export interface SelectProps extends VariantProps<typeof selectVariants> {
+  options: SelectOption[];
   placeholder?: React.ReactNode;
   className?: string;
   icon?: IconProp;
@@ -116,11 +125,51 @@ export interface SelectProps
   value?: string;
   intent?: 'primary' | 'secondary';
   hideChevron?: boolean;
+  disabled?: boolean;
+  onValueChange?: (value: string) => void;
+
+  // New props for search and create functionality
+  /**
+   * If true, shows a search input in the dropdown.
+   * @default false
+   */
+  searchable?: boolean;
+
+  /**
+   * If true, allows creating new items by typing and pressing Enter.
+   * Requires searchable to be true (automatically enabled if allowCreate is true).
+   * @default false
+   */
+  allowCreate?: boolean;
+
+  /**
+   * Callback fired when a new item is created.
+   * Should return the new option, or void if handled externally.
+   */
+  onCreate?: (inputValue: string) => SelectOption | void;
+
+  /**
+   * Label shown next to created items.
+   * @default "(created)"
+   */
+  createdLabel?: React.ReactNode;
+
+  /**
+   * Placeholder text for the search input.
+   * @default "Search..."
+   */
+  searchPlaceholder?: string;
+
+  /**
+   * Content displayed when no options match search.
+   * @default "No results found."
+   */
+  emptyIndicator?: React.ReactNode;
 }
 
 export const Select: React.FC<SelectProps> = ({
   options,
-  placeholder,
+  placeholder = 'Select an option',
   className,
   icon: Icon,
   invalid = false,
@@ -128,106 +177,304 @@ export const Select: React.FC<SelectProps> = ({
   intent = 'primary',
   value,
   hideChevron = false,
-  ...props
+  disabled = false,
+  onValueChange,
+  searchable = false,
+  allowCreate = false,
+  onCreate,
+  createdLabel = '(created)',
+  searchPlaceholder = 'Search...',
+  emptyIndicator = 'No results found.',
 }) => {
-  const rootProps: React.ComponentProps<typeof RadixSelect.Root> = {
-    ...props,
+  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
+  const [searchValue, setSearchValue] = React.useState('');
+  const [createdOptions, setCreatedOptions] = React.useState<SelectOption[]>(
+    []
+  );
+
+  // Enable search if allowCreate is true
+  const showSearch = searchable || allowCreate;
+
+  // Clear search when popover closes
+  React.useEffect(() => {
+    if (!isPopoverOpen) {
+      setSearchValue('');
+    }
+  }, [isPopoverOpen]);
+
+  // Get all options including created ones
+  const allOptions = React.useMemo(() => {
+    return [...createdOptions, ...options];
+  }, [createdOptions, options]);
+
+  // Get only selectable options (not groups/separators)
+  const selectableOptions = React.useMemo(() => {
+    return allOptions.filter(
+      (opt) => opt.type !== 'Group' && opt.type !== 'Separator'
+    );
+  }, [allOptions]);
+
+  const getOptionByValue = React.useCallback(
+    (val: string): SelectOption | undefined => {
+      return selectableOptions.find((opt) => opt.value === val);
+    },
+    [selectableOptions]
+  );
+
+  const selectedOption = value ? getOptionByValue(value) : undefined;
+
+  const filterItems = React.useCallback((itemValue: string, search: string) => {
+    const [, label] = itemValue.split(':');
+    if (label && label.toLowerCase().includes(search.toLowerCase())) {
+      return 1;
+    }
+    return 0;
+  }, []);
+
+  const handleSelect = (optionValue: string) => {
+    if (disabled) return;
+    const option = getOptionByValue(optionValue);
+    if (option?.disabled) return;
+
+    onValueChange?.(optionValue);
+    setIsPopoverOpen(false);
   };
-  if (value !== undefined) {
-    rootProps.value = value;
-  }
+
+  const handleCreate = () => {
+    if (!allowCreate || !searchValue.trim()) return;
+
+    const trimmedValue = searchValue.trim();
+
+    // Check if value already exists
+    const exists = selectableOptions.some(
+      (opt) =>
+        String(opt.label).toLowerCase() === trimmedValue.toLowerCase() ||
+        opt.value.toLowerCase() === trimmedValue.toLowerCase()
+    );
+
+    if (exists) return;
+
+    let newOption: SelectOption;
+
+    if (onCreate) {
+      // Parent manages created options via onCreate callback
+      const result = onCreate(trimmedValue);
+      if (result) {
+        newOption = { ...result, isCreated: true };
+        onValueChange?.(newOption.value);
+      }
+    } else {
+      // No onCreate provided - use internal state to track created items
+      newOption = {
+        value: trimmedValue,
+        label: trimmedValue,
+        isCreated: true,
+      };
+      setCreatedOptions((prev) => [newOption, ...prev]);
+      onValueChange?.(newOption.value);
+    }
+
+    setSearchValue('');
+    setIsPopoverOpen(false);
+  };
+
+  const handleInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && allowCreate && searchValue.trim()) {
+      const exactMatch = selectableOptions.some(
+        (opt) =>
+          String(opt.label).toLowerCase() === searchValue.trim().toLowerCase()
+      );
+
+      if (!exactMatch) {
+        event.preventDefault();
+        handleCreate();
+      }
+    }
+  };
+
+  const showCreateOption =
+    allowCreate &&
+    searchValue.trim() &&
+    !selectableOptions.some(
+      (opt) =>
+        String(opt.label).toLowerCase() === searchValue.trim().toLowerCase()
+    );
+
+  // Separate created options from original options
+  const createdItems = allOptions.filter((opt) => opt.isCreated);
+  const originalOptions = options.filter((opt) => !opt.isCreated);
 
   return (
-    <RadixSelect.Root {...rootProps}>
-      <RadixSelect.Trigger
-        className={cn(
-          selectVariants({ variant, intent, invalid }),
-          'group',
-          className
-        )}
-      >
-        <div className="inline-flex items-center">
-          {renderIcon(Icon, {
-            className: cn('text-body-secondary mr-xxs h-3.5 w-3.5'),
-          })}
-          <RadixSelect.Value
-            placeholder={placeholder || 'Select an option'}
-            className={cn({
-              'text-sm': variant === 'compact',
-            })}
-          />
-        </div>
-        {!hideChevron && (
-          <RadixSelect.Icon
-            className={cn('text-body-primary h-3.5 w-3.5', {
-              'text-body-disabled': props.disabled,
-            })}
-          >
-            <IconChevronDown
-              className="top-0.5 relative h-full w-full transition-transform
-                duration-200 group-data-[state=open]:rotate-180"
-            />
-          </RadixSelect.Icon>
-        )}
-      </RadixSelect.Trigger>
-      <RadixSelect.Portal>
-        <RadixSelect.Content
-          position="popper"
-          className={cn(selectContentVariants({ variant }), className)}
+    <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          data-state={isPopoverOpen ? 'open' : 'closed'}
+          className={cn(
+            selectVariants({ variant, intent, invalid }),
+            'group',
+            className
+          )}
+          onClick={() => !disabled && setIsPopoverOpen(!isPopoverOpen)}
         >
-          <RadixSelect.ScrollUpButton />
-          <RadixSelect.Viewport className="min-w-[var(--radix-select-trigger-width)]">
-            {options.map((option, index) => {
-              switch (option.type) {
-                case 'Group':
+          <div className="inline-flex items-center">
+            {renderIcon(Icon, {
+              className: cn('text-body-secondary mr-xxs h-3.5 w-3.5'),
+            })}
+            <span
+              className={cn(
+                'truncate',
+                !selectedOption && 'text-body-placeholder',
+                variant === 'compact' && 'text-sm'
+              )}
+            >
+              {selectedOption ? (
+                <span className="gap-xs flex items-center">
+                  {renderIcon(selectedOption.icon, {
+                    className: 'h-4 w-4',
+                  })}
+                  {selectedOption.label}
+                  {selectedOption.isCreated && (
+                    <span className="text-body-secondary text-sm">
+                      {createdLabel}
+                    </span>
+                  )}
+                </span>
+              ) : (
+                placeholder
+              )}
+            </span>
+          </div>
+          {!hideChevron && (
+            <IconChevronDown
+              className={cn(
+                `text-body-primary h-3.5 w-3.5 transition-transform
+                duration-200`,
+                isPopoverOpen && 'rotate-180',
+                disabled && 'text-body-disabled'
+              )}
+            />
+          )}
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        className={cn(selectContentVariants({ variant }), 'p-0')}
+        style={{ minWidth: 'var(--radix-popover-trigger-width)' }}
+        align="start"
+      >
+        <Command filter={filterItems}>
+          {showSearch && (
+            <CommandInput
+              placeholder={searchPlaceholder}
+              value={searchValue}
+              onValueChange={setSearchValue}
+              onKeyDown={handleInputKeyDown}
+            />
+          )}
+
+          <CommandList>
+            <CommandEmpty>
+              {showCreateOption ? null : emptyIndicator}
+            </CommandEmpty>
+
+            {/* Create new item option */}
+            {showCreateOption && (
+              <CommandGroup>
+                <CommandItem
+                  value={`create:${searchValue}`}
+                  onSelect={handleCreate}
+                  className={cn(
+                    selectItemVariants({ variant, isSelected: false }),
+                    'text-interactive-primary-default'
+                  )}
+                >
+                  <IconPlus className="h-4 w-4 mr-xs" />
+                  <span>Create &quot;{searchValue.trim()}&quot;</span>
+                </CommandItem>
+              </CommandGroup>
+            )}
+
+            {/* Created items */}
+            {createdItems.length > 0 && (
+              <CommandGroup heading="Created Items">
+                {createdItems.map((option) => {
+                  const isSelected = value === option.value;
                   return (
-                    <RadixSelect.Group key={index}>
-                      <RadixSelect.Label>{option.label}</RadixSelect.Label>
-                    </RadixSelect.Group>
-                  );
-                case 'Separator':
-                  return (
-                    <RadixSelect.Separator
-                      key={index}
-                      className="border-divider-default m-[5px] h-px border-b"
-                    />
-                  );
-                default:
-                  return (
-                    <RadixSelect.Item
-                      key={index}
-                      value={option.value}
-                      disabled={option.disabled ?? false}
-                      className={selectItemVariants({
-                        variant,
-                        isSelected: value === option.value,
-                      })}
+                    <CommandItem
+                      key={option.value}
+                      value={`${option.value}:${option.label}`}
+                      onSelect={() => handleSelect(option.value)}
+                      disabled={Boolean(option.disabled)}
+                      className={selectItemVariants({ variant, isSelected })}
                     >
                       {renderIcon(option.icon, {
                         className: cn('h-5 w-5', {
                           '-ml-xxs': variant === 'default',
                           'mr-xxs': variant === 'compact',
-                          'text-interactive-disabled': option.disabled,
                         }),
                       })}
-                      <RadixSelect.ItemText
-                        className={cn('flex-1', {
-                          'text-interactive-disabled': option.disabled,
-                        })}
-                      >
-                        {option.label}
-                      </RadixSelect.ItemText>
-                      <RadixSelect.ItemIndicator />
-                    </RadixSelect.Item>
+                      <span className="flex-1">{option.label}</span>
+                      <span className="text-body-secondary text-sm">
+                        {createdLabel}
+                      </span>
+                    </CommandItem>
                   );
-              }
-            })}
-          </RadixSelect.Viewport>
-          <RadixSelect.ScrollDownButton />
-          <RadixSelect.Arrow />
-        </RadixSelect.Content>
-      </RadixSelect.Portal>
-    </RadixSelect.Root>
+                })}
+              </CommandGroup>
+            )}
+
+            {/* Original options (supporting Group/Separator types) */}
+            <CommandGroup
+              heading={createdItems.length > 0 ? 'Available Items' : undefined}
+            >
+              {originalOptions.map((option, index) => {
+                if (option.type === 'Group') {
+                  return (
+                    <div
+                      key={index}
+                      className="text-body-secondary px-md py-1.5 text-xs
+                        font-semibold"
+                    >
+                      {option.label}
+                    </div>
+                  );
+                }
+
+                if (option.type === 'Separator') {
+                  return (
+                    <div
+                      key={index}
+                      className="border-divider-default my-1 h-px border-b"
+                    />
+                  );
+                }
+
+                const isSelected = value === option.value;
+                return (
+                  <CommandItem
+                    key={option.value}
+                    value={`${option.value}:${option.label}`}
+                    onSelect={() => handleSelect(option.value)}
+                    disabled={Boolean(option.disabled)}
+                    className={selectItemVariants({ variant, isSelected })}
+                  >
+                    {renderIcon(option.icon, {
+                      className: cn('h-5 w-5', {
+                        '-ml-xxs': variant === 'default',
+                        'mr-xxs': variant === 'compact',
+                      }),
+                    })}
+                    <span className="flex-1">{option.label}</span>
+                  </CommandItem>
+                );
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   );
 };
 


### PR DESCRIPTION
## issue information
<!--
* githubのissueタイトルとURL
* slackでのコミュニケーションログ
* Notionでの関連ドキュメントリンクなど
-->

## Overview
We need the ability to create new items on the select drop down as well as multiselect. sort of behave like combo box.
Rather than creating a seperate combo boxes this PR add the ability to add items directly to the multiselect and select components
<!--
* 変更の理由や内容の説明
-->
## Dependencies
<!--
* 変更の影響を受けると考えられる機能や環境
-->

## Step to test
<!--
* 動作確認手順
-->

## Additional information
<!--
* 特にレビューしてほしいポイントなどの補足情報
-->
