### PR TITLE
fix(TextArea): Correct CSS on focus

### DIFF
--- a/src/components/TextArea/TextArea.stories.tsx
+++ b/src/components/TextArea/TextArea.stories.tsx
@@ -15,9 +15,17 @@ const meta: Meta<typeof TextArea> = {
 export default meta;
 
 const Template: StoryFn<typeof TextArea> = (args) => <TextArea {...args} />;
+
 export const Default = Template.bind({});
 Default.args = {
   placeholder: 'Placeholder',
   characterLimit: 0,
   invalid: false,
+};
+
+export const Invalid = Template.bind({});
+Invalid.args = {
+  placeholder: 'This field has an error',
+  characterLimit: 0,
+  invalid: true,
 };

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -5,16 +5,16 @@ import { cva } from 'class-variance-authority';
 import { cn } from '../../utils';
 
 const textareaVariants = cva(
-  `border-interactive-default bg-surface-primary px-md py-sm
+  `border-interactive-default bg-surface-primary px-md py-sm text-body-primary
   focus:border-interactive-selected disabled:border-interactive-disabled
   disabled:bg-surface-disabled disabled:text-body-disabled
-  hover:border-interactive-hover h-12 min-h-30 rounded w-full border
-  focus:ring-4 focus:outline-0`,
+  hover:border-interactive-hover h-12 min-h-30 rounded
+  focus:ring-interactive-focused w-full border focus:ring-4 focus:outline-0`,
   {
     variants: {
       invalid: {
-        false: 'text-body-primary focus:ring-interactive-focused',
-        true: `border-shape-interactive-alert-default!
+        false: '',
+        true: `!border-shape-interactive-alert-default
         focus:ring-interactive-alert-focused`,
       },
     },


### PR DESCRIPTION
## issue information
Related to this [PR](https://github.com/GoodMoneyger/sds_scan_general/pull/1875#issue-3864487747)'s comment.

## Before change
<img width="636" height="258" alt="Screenshot 2026-02-04 at 18 26 50" src="https://github.com/user-attachments/assets/6bab6c78-dd99-40bc-b740-b740714e05bc" />


## After change
<img width="757" height="365" alt="Screenshot 2026-02-04 at 18 26 44" src="https://github.com/user-attachments/assets/d239f4b9-ef4f-4d33-876e-d4a188e9d329" />

## Tests
Added a story for invalid variant.