### PR TITLE
SearchBar: Fix dangling value ambiguity when clicking search

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -321,7 +321,19 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
                 size,
               })
             )}
-            onClick={() => onSearch?.(keywords)}
+            onClick={() => {
+              let finalKeywords = keywords;
+              if (value.trim()) {
+                finalKeywords = [...keywords, value.trim()];
+                setKeywords(finalKeywords);
+                if (onChange) {
+                  onChange({
+                    target: { value: '' },
+                  } as React.ChangeEvent<HTMLInputElement>);
+                }
+              }
+              onSearch?.(finalKeywords);
+            }}
             disabled={disabled}
           >
             {searchButtonText}


### PR DESCRIPTION
## issue information
This PR fixes an issue with the search bar in which the currently entered value is not set as search term when clicking the search button.

## Overview
Fix search button handler by ensuring the currently entered value is converted to a proper value (tag) before calling the passed search handler

## Dependencies
<!--
* 変更の影響を受けると考えられる機能や環境
-->

## Step to test
Can be tested on storybook

## Additional information
<!--
* 特にレビューしてほしいポイントなどの補足情報
-->
