### PR TITLE
feat(Dialog): Add onOpenAutoFocus prop to control focus behavior

### DIFF
--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import type { Meta, StoryFn } from 'storybook/react-vite';
 
 import { Button } from '../Button';
+import { TextField } from '../TextField';
 
 import type { DialogProps } from './Dialog';
 import { Dialog } from './Dialog';
@@ -186,6 +187,52 @@ WithOnCancelControl.args = {
     {
       label: 'Save',
       value: 'saved',
+      intent: 'primary',
+    },
+  ],
+};
+
+export const WithPreventedAutoFocus: StoryFn<DialogProps> = (args) => {
+  const [isOpen, setIsOpen] = useState(args.isOpen);
+
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      <Button intent="secondary" onClick={() => setIsOpen(true)}>
+        Open Modal
+      </Button>
+      <Dialog
+        {...args}
+        isOpen={isOpen}
+        onClose={handleClose}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="gap-lg flex flex-col">
+          <p className="text-body-secondary text-sm">
+            This dialog uses <code>onOpenAutoFocus</code> to prevent the input
+            from being focused when the dialog opens.
+          </p>
+          <div className="gap-xs flex flex-col">
+            <label className="text-body-primary text-sm font-medium">
+              Search
+            </label>
+            <TextField placeholder="Type to search..." />
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
+};
+WithPreventedAutoFocus.args = {
+  isOpen: false,
+  title: 'Search Dialog',
+  actions: [
+    {
+      label: 'Search',
+      value: true,
       intent: 'primary',
     },
   ],

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -26,6 +26,9 @@ export interface DialogProps
   cancellable?: boolean;
   cancelButtonLabel?: ReactNode;
   allowClickOutside?: boolean;
+  onOpenAutoFocus?: React.ComponentProps<
+    typeof RadixDialog.Content
+  >['onOpenAutoFocus'];
 }
 
 const defaultActions: DialogAction[] = [
@@ -47,6 +50,7 @@ export const Dialog: React.FC<DialogProps> = ({
   cancellable = true,
   cancelButtonLabel = 'キャンセル',
   allowClickOutside = true,
+  onOpenAutoFocus,
 }) => {
   const [loading, setLoading] = React.useState<number>(-1);
 
@@ -106,6 +110,7 @@ export const Dialog: React.FC<DialogProps> = ({
             aria-describedby={undefined}
             onPointerDownOutside={handleOutsideClick}
             onEscapeKeyDown={handleEscapeKeyDown}
+            onOpenAutoFocus={onOpenAutoFocus}
             className="bg-surface-primary rounded-lg z-dialog max-w-screen-sm
               min-w-96 fixed top-1/2 left-1/2 flex max-h-[90vh] w-2/3
               -translate-x-1/2 -translate-y-1/2 transform flex-col


### PR DESCRIPTION
## issue information
<!--
* githubのissueタイトルとURL
* slackでのコミュニケーションログ
* Notionでの関連ドキュメントリンクなど
-->

## Overview
This PR add onOpenAutoFocus prop to control the focus behavior in Dialog component. The reasoning for this is given in the following PR
https://github.com/GoodMoneyger/sds_scan_general/pull/1944
<!--
* 変更の理由や内容の説明
-->
## Dependencies
<!--
* 変更の影響を受けると考えられる機能や環境
-->

## Step to test
<!--
* 動作確認手順
-->

## Additional information
<!--
* 特にレビューしてほしいポイントなどの補足情報
-->
