### PR TITLE
Add TableCoverMessage component for error and empty states

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -18,6 +18,7 @@ import {
   TableBody,
   TableCell,
   TableHeadSortButton,
+  TableCoverMessage,
 } from './Table';
 import { TableRowOverlay } from './TableRowOverlay';
 
@@ -525,6 +526,155 @@ const LoadingTemplate: StoryFn = () => (
 );
 
 export const Loading = LoadingTemplate.bind({});
+
+const CoverMessageTemplate: StoryFn = () => {
+  const [state, setState] = React.useState<'data' | 'error' | 'empty'>('data');
+
+  return (
+    <div className="gap-md flex flex-col">
+      <div className="gap-xs flex">
+        <Button
+          size="sm"
+          intent={state === 'data' ? 'primary' : 'secondary'}
+          onClick={() => setState('data')}
+        >
+          Show Data
+        </Button>
+        <Button
+          size="sm"
+          intent={state === 'error' ? 'primary' : 'secondary'}
+          onClick={() => setState('error')}
+        >
+          Show Error
+        </Button>
+        <Button
+          size="sm"
+          intent={state === 'empty' ? 'primary' : 'secondary'}
+          onClick={() => setState('empty')}
+        >
+          Show Empty
+        </Button>
+      </div>
+
+      <div className="max-w-4xl overflow-x-auto">
+        <Table className="w-max">
+          <TableHeader>
+            <TableRow>
+              <TableHead>
+                <Checkbox label="" />
+              </TableHead>
+              <TableHead>SDSファイル名</TableHead>
+              <TableHead>製品名</TableHead>
+              <TableHead>製造者</TableHead>
+              <TableHead>データ化ステータス</TableHead>
+              <TableHead>
+                PDFアップロード日 <TableHeadSortButton sortOrder="asc" />
+              </TableHead>
+              <TableHead>担当ユーザー</TableHead>
+              <TableHead>
+                SDS改訂日 <TableHeadSortButton sortOrder="asc" />
+              </TableHead>
+              <TableHead>改訂ステータス</TableHead>
+              <TableHead>担当部署</TableHead>
+              <TableHead>タグ</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {state === 'error' ? (
+              <TableCoverMessage>
+                <div
+                  className="gap-sm text-body-secondary flex flex-col
+                    items-center"
+                >
+                  <span>データの読み込み中にエラーが発生しました</span>
+                  <Button
+                    size="sm"
+                    intent="tertiary"
+                    onClick={() => setState('data')}
+                  >
+                    リロード
+                  </Button>
+                </div>
+              </TableCoverMessage>
+            ) : state === 'empty' ? (
+              <TableCoverMessage className="text-body-secondary">
+                データがありません
+              </TableCoverMessage>
+            ) : (
+              data.slice(0, 3).map((row, index) => (
+                <TableRow key={index}>
+                  <TableCell>
+                    <Checkbox label="" />
+                  </TableCell>
+                  <TableCell>
+                    <div className="gap-2 inline-flex items-center">
+                      <div className="gap-1 flex items-center">
+                        {row.sdsName}
+                      </div>
+                      <a href="#">
+                        <IconExternalLink
+                          size={20}
+                          className="text-shape-primary"
+                        />
+                      </a>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Tag className="uppercase">{row.productName}</Tag>
+                  </TableCell>
+                  <TableCell>{row.manufacturer}</TableCell>
+                  <TableCell>
+                    <StatusIndicator level={row.dataStatusLevel}>
+                      {row.dataStatus}
+                    </StatusIndicator>
+                  </TableCell>
+                  <TableCell>{row.pdfUploadDate}</TableCell>
+                  <TableCell>
+                    <Tag>{row.assignedUser}</Tag>
+                  </TableCell>
+                  <TableCell>{row.sdsRevisionDate}</TableCell>
+                  <TableCell>
+                    <StatusIndicator level={row.revisionStatusLevel}>
+                      {row.revisionStatus}
+                    </StatusIndicator>
+                  </TableCell>
+                  <TableCell>
+                    <div className="gap-xs flex flex-wrap">
+                      {row.departments.map((dept, i) => (
+                        <Tag key={i}>{dept}</Tag>
+                      ))}
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="gap-xs flex flex-wrap">
+                      {row.tags.map((tag, i) => (
+                        <Tag key={i} colorCode={tag.colorCode}>
+                          {tag.label}
+                        </Tag>
+                      ))}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+};
+
+export const WithCoverMessage = CoverMessageTemplate.bind({});
+WithCoverMessage.parameters = {
+  docs: {
+    description: {
+      story:
+        'Demonstrates the TableCoverMessage component for displaying error messages, ' +
+        'empty states, or any custom overlay message. Use conditional rendering to show ' +
+        'the cover message instead of table rows.',
+    },
+  },
+};
 
 const RowOverlayTemplate: StoryFn = () => {
   const [openRowId, setOpenRowId] = React.useState<string | null>(null);

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -42,17 +42,17 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(
 
     return (
       <TableContext.Provider value={contextValue}>
-        <div
-          className="border-surface-default bg-surface-primary relative border"
+        <table
+          ref={ref}
+          className={cn(
+            `border-surface-default bg-surface-primary relative w-full
+            caption-bottom border`,
+            className
+          )}
+          {...props}
         >
-          <table
-            ref={ref}
-            className={cn('w-full caption-bottom', className)}
-            {...props}
-          >
-            {children}
-          </table>
-        </div>
+          {children}
+        </table>
       </TableContext.Provider>
     );
   }
@@ -99,6 +99,34 @@ export interface TableBodyProps
   loadingText?: React.ReactNode;
 }
 
+export interface TableCoverMessageProps
+  extends React.HTMLAttributes<HTMLTableRowElement> {
+  children: React.ReactNode;
+}
+
+const TableCoverMessage = React.forwardRef<
+  HTMLTableRowElement,
+  TableCoverMessageProps
+>(({ className, children, ...props }, ref) => (
+  <tr ref={ref} {...props}>
+    <td
+      className="py-sm min-h-12 px-lg sticky
+        left-[calc((100%+var(--cc-side-navigation-width,0px))/2)] min-w-fit
+        text-center align-middle"
+    >
+      <div
+        className={cn(
+          'flex w-max -translate-x-1/2 transform items-center',
+          className
+        )}
+      >
+        {children}
+      </div>
+    </td>
+  </tr>
+));
+TableCoverMessage.displayName = 'TableCoverMessage';
+
 const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
   (
     {
@@ -118,20 +146,9 @@ const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(
     return (
       <tbody ref={ref} className={className} {...props}>
         {loading ? (
-          <tr>
-            <td
-              className="py-sm h-12 sticky
-                left-[calc((100vw+var(--cc-side-navigation-width,0px))/2)]
-                min-w-fit px-[1.44rem] text-center align-middle"
-            >
-              <div
-                className="top-0 absolute flex h-full w-max -translate-x-1/2
-                  transform items-center"
-              >
-                {loadingText}
-              </div>
-            </td>
-          </tr>
+          <TableCoverMessage className="text-body-secondary">
+            {loadingText}
+          </TableCoverMessage>
         ) : (
           children
         )}
@@ -289,4 +306,5 @@ export {
   TableCell,
   TableCaption,
   TableHeadSortButton,
+  TableCoverMessage,
 };


### PR DESCRIPTION
## issue information

  Added a new `TableCoverMessage` component that allows displaying arbitrary overlay messages in table
  bodies (e.g., error messages, empty states). 

Background is that the loading message within the table uses a special markup and styling that makes it horizontally sticky, such that the message always appears properly centered in the screen, regardless of the width of the table. This PR basically makes this styling available for user-land for other messages as well.

<img width="935" height="238" alt="image" src="https://github.com/user-attachments/assets/353d780b-e233-469f-89b9-52193b370aee" />


  Changes:
  - Extracted table overlay rendering into new `TableCoverMessage` component
  - Refactored TableBody to use `TableCoverMessage` internally for loading states (maintains backward
  compatibility)
  - Exported `TableCoverMessage` for consumer use with conditional rendering
  - Added Storybook example demonstrating error and empty state patterns

  Usage:
```tsx
  <TableBody>
    {error ? (
      <TableCoverMessage>Error loading data</TableCoverMessage>
    ) : data.length === 0 ? (
      <TableCoverMessage>No data available</TableCoverMessage>
    ) : (
      rows.map(row => <TableRow>...</TableRow>)
    )}
  </TableBody>
```

## Step to test
<!--
* 動作確認手順
-->

## Additional information
Need this to show the error message within the table, when the data fetching failed as per the design:
https://www.figma.com/design/f46iSbgpNKClOOIDRfG7AB/Master-v2.0-SDS%E7%AE%A1%E7%90%86%EF%BC%88JP_Products%EF%BC%89?node-id=27293-105523&m=dev


