### PR TITLE
feat(TabBar): Add overflow dropdown for overflowing tabs

### DIFF
--- a/src/components/TabBar/TabBar.stories.tsx
+++ b/src/components/TabBar/TabBar.stories.tsx
@@ -102,3 +102,59 @@ export const AllStates: Story = {
     </div>
   ),
 };
+
+// Overflow story - constrained width to trigger overflow
+export const Overflow: Story = {
+  render: (args) => (
+    <div style={{ maxWidth: 400 }}>
+      <TabBar {...args}>
+        <Tab value="tab1" label="タブ1" />
+        <Tab value="tab2" label="タブ2" />
+        <Tab value="tab3" label="タブ3" />
+        <Tab value="tab4" label="タブ4" />
+        <Tab value="tab5" label="タブ5" />
+        <Tab value="tab6" label="タブ6" />
+        <Tab value="tab7" label="タブ7" />
+      </TabBar>
+    </div>
+  ),
+};
+
+// Overflow with controlled state - shows active tab in overflow
+const OverflowWithActiveInDropdownRender = () => {
+  const [value, setValue] = React.useState('tab6');
+  return (
+    <div style={{ maxWidth: 400 }}>
+      <TabBar value={value} onValueChange={setValue}>
+        <Tab value="tab1" label="タブ1" />
+        <Tab value="tab2" label="タブ2" />
+        <Tab value="tab3" label="タブ3" />
+        <Tab value="tab4" label="タブ4" />
+        <Tab value="tab5" label="タブ5" />
+        <Tab value="tab6" label="タブ6" />
+        <Tab value="tab7" label="タブ7" />
+      </TabBar>
+    </div>
+  );
+};
+
+export const OverflowWithActiveInDropdown: Story = {
+  render: () => <OverflowWithActiveInDropdownRender />,
+};
+
+// Overflow with custom label
+export const OverflowCustomLabel: Story = {
+  render: (args) => (
+    <div style={{ maxWidth: 400 }}>
+      <TabBar {...args} moreLabel={(count) => `他${count}件`}>
+        <Tab value="tab1" label="タブ1" />
+        <Tab value="tab2" label="タブ2" />
+        <Tab value="tab3" label="タブ3" />
+        <Tab value="tab4" label="タブ4" />
+        <Tab value="tab5" label="タブ5" />
+        <Tab value="tab6" label="タブ6" />
+        <Tab value="tab7" label="タブ7" />
+      </TabBar>
+    </div>
+  ),
+};

--- a/src/components/TabBar/TabBar.stories.tsx
+++ b/src/components/TabBar/TabBar.stories.tsx
@@ -45,13 +45,13 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: (args) => (
     <TabBar {...args}>
-      <Tab value="tab1" label="タブ1" />
-      <Tab value="tab2" label="タブ2" />
-      <Tab value="tab3" label="タブ3" />
-      <Tab value="tab4" label="タブ4" />
-      <Tab value="tab5" label="タブ5" />
-      <Tab value="tab6" label="タブ6" />
-      <Tab value="tab7" label="タブ7" />
+      <Tab value="tab1">タブ1</Tab>
+      <Tab value="tab2">タブ2</Tab>
+      <Tab value="tab3">タブ3</Tab>
+      <Tab value="tab4">タブ4</Tab>
+      <Tab value="tab5">タブ5</Tab>
+      <Tab value="tab6">タブ6</Tab>
+      <Tab value="tab7">タブ7</Tab>
     </TabBar>
   ),
 };
@@ -63,13 +63,13 @@ export const Small: Story = {
   },
   render: (args) => (
     <TabBar {...args}>
-      <Tab value="tab1" label="タブ1" size={args.size} />
-      <Tab value="tab2" label="タブ2" size={args.size} />
-      <Tab value="tab3" label="タブ3" size={args.size} />
-      <Tab value="tab4" label="タブ4" size={args.size} />
-      <Tab value="tab5" label="タブ5" size={args.size} />
-      <Tab value="tab6" label="タブ6" size={args.size} />
-      <Tab value="tab7" label="タブ7" size={args.size} />
+      <Tab value="tab1">タブ1</Tab>
+      <Tab value="tab2">タブ2</Tab>
+      <Tab value="tab3">タブ3</Tab>
+      <Tab value="tab4">タブ4</Tab>
+      <Tab value="tab5">タブ5</Tab>
+      <Tab value="tab6">タブ6</Tab>
+      <Tab value="tab7">タブ7</Tab>
     </TabBar>
   ),
 };
@@ -82,10 +82,12 @@ export const AllStates: Story = {
       <div>
         <h3 className="text-lg font-medium mb-md">Normal Size - All States</h3>
         <TabBar defaultValue="tab3">
-          <Tab value="tab1" label="デフォルト" />
-          <Tab value="tab2" label="ホバー時" />
-          <Tab value="tab3" label="選択中" />
-          <Tab value="tab4" label="利用不可時" disabled />
+          <Tab value="tab1">デフォルト</Tab>
+          <Tab value="tab2">ホバー時</Tab>
+          <Tab value="tab3">選択中</Tab>
+          <Tab value="tab4" disabled>
+            利用不可時
+          </Tab>
         </TabBar>
       </div>
 
@@ -93,10 +95,12 @@ export const AllStates: Story = {
       <div>
         <h3 className="text-lg font-medium mb-md">Small Size - All States</h3>
         <TabBar size="small" defaultValue="tab3">
-          <Tab value="tab1" label="デフォルト" size="small" />
-          <Tab value="tab2" label="ホバー時" size="small" />
-          <Tab value="tab3" label="選択中" size="small" />
-          <Tab value="tab4" label="利用不可時" size="small" disabled />
+          <Tab value="tab1">デフォルト</Tab>
+          <Tab value="tab2">ホバー時</Tab>
+          <Tab value="tab3">選択中</Tab>
+          <Tab value="tab4" disabled>
+            利用不可時
+          </Tab>
         </TabBar>
       </div>
     </div>
@@ -108,13 +112,13 @@ export const Overflow: Story = {
   render: (args) => (
     <div style={{ maxWidth: 400 }}>
       <TabBar {...args}>
-        <Tab value="tab1" label="タブ1" />
-        <Tab value="tab2" label="タブ2" />
-        <Tab value="tab3" label="タブ3" />
-        <Tab value="tab4" label="タブ4" />
-        <Tab value="tab5" label="タブ5" />
-        <Tab value="tab6" label="タブ6" />
-        <Tab value="tab7" label="タブ7" />
+        <Tab value="tab1">タブ1</Tab>
+        <Tab value="tab2">タブ2</Tab>
+        <Tab value="tab3">タブ3</Tab>
+        <Tab value="tab4">タブ4</Tab>
+        <Tab value="tab5">タブ5</Tab>
+        <Tab value="tab6">タブ6</Tab>
+        <Tab value="tab7">タブ7</Tab>
       </TabBar>
     </div>
   ),
@@ -126,13 +130,13 @@ const OverflowWithActiveInDropdownRender = () => {
   return (
     <div style={{ maxWidth: 400 }}>
       <TabBar value={value} onValueChange={setValue}>
-        <Tab value="tab1" label="タブ1" />
-        <Tab value="tab2" label="タブ2" />
-        <Tab value="tab3" label="タブ3" />
-        <Tab value="tab4" label="タブ4" />
-        <Tab value="tab5" label="タブ5" />
-        <Tab value="tab6" label="タブ6" />
-        <Tab value="tab7" label="タブ7" />
+        <Tab value="tab1">タブ1</Tab>
+        <Tab value="tab2">タブ2</Tab>
+        <Tab value="tab3">タブ3</Tab>
+        <Tab value="tab4">タブ4</Tab>
+        <Tab value="tab5">タブ5</Tab>
+        <Tab value="tab6">タブ6</Tab>
+        <Tab value="tab7">タブ7</Tab>
       </TabBar>
     </div>
   );
@@ -147,13 +151,13 @@ export const OverflowCustomLabel: Story = {
   render: (args) => (
     <div style={{ maxWidth: 400 }}>
       <TabBar {...args} moreLabel={(count) => `他${count}件`}>
-        <Tab value="tab1" label="タブ1" />
-        <Tab value="tab2" label="タブ2" />
-        <Tab value="tab3" label="タブ3" />
-        <Tab value="tab4" label="タブ4" />
-        <Tab value="tab5" label="タブ5" />
-        <Tab value="tab6" label="タブ6" />
-        <Tab value="tab7" label="タブ7" />
+        <Tab value="tab1">タブ1</Tab>
+        <Tab value="tab2">タブ2</Tab>
+        <Tab value="tab3">タブ3</Tab>
+        <Tab value="tab4">タブ4</Tab>
+        <Tab value="tab5">タブ5</Tab>
+        <Tab value="tab6">タブ6</Tab>
+        <Tab value="tab7">タブ7</Tab>
       </TabBar>
     </div>
   ),

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -68,6 +68,23 @@ const moreButtonVariants = cva(
   }
 );
 
+function useHasPointerFine() {
+  const [hasFine, setHasFine] = React.useState(
+    () =>
+      typeof window !== 'undefined' &&
+      window.matchMedia('(pointer: fine)').matches
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia('(pointer: fine)');
+    const onChange = () => setHasFine(mql.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return hasFine;
+}
+
 function extractTabs(children: React.ReactNode) {
   const tabs: React.ReactElement<TabProps>[] = [];
   React.Children.forEach(children, (child) => {
@@ -91,6 +108,9 @@ export const TabBar = React.forwardRef<
   TabBarProps
 >(({ className, size, children, moreLabel, ...props }, ref) => {
   const effectiveSize = size ?? 'normal';
+  // On touch devices, the tab bar scrolls horizontally instead of collapsing
+  // into a dropdown. The dropdown is only shown on pointer: fine (mouse/trackpad).
+  const useDropdown = useHasPointerFine();
 
   const listRef = React.useRef<HTMLDivElement>(null);
   const moreRef = React.useRef<HTMLDivElement>(null);
@@ -108,6 +128,12 @@ export const TabBar = React.forwardRef<
   const [measured, setMeasured] = React.useState(false);
 
   const calculateVisibleTabs = React.useCallback(() => {
+    if (!useDropdown) {
+      setVisibleCount(tabs.length);
+      setMeasured(true);
+      return;
+    }
+
     const list = listRef.current;
     if (!list) return;
 
@@ -149,7 +175,7 @@ export const TabBar = React.forwardRef<
 
     setVisibleCount(Math.max(fitCount, 1));
     setMeasured(true);
-  }, [tabs]);
+  }, [tabs, useDropdown]);
 
   React.useEffect(() => {
     const list = listRef.current;
@@ -179,7 +205,11 @@ export const TabBar = React.forwardRef<
     <RadixTabs.Root ref={ref} className={cn('w-full', className)} {...props}>
       <RadixTabs.List
         ref={listRef}
-        className={cn(tabBarVariants({ size: effectiveSize }), 'w-full')}
+        className={cn(
+          tabBarVariants({ size: effectiveSize }),
+          'w-full',
+          !useDropdown && 'overflow-x-auto'
+        )}
         role="tablist"
       >
         {tabs.map((tab, index) =>

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -12,17 +12,6 @@ import {
   DropdownItem,
 } from '../DropdownMenu';
 
-// TabBar Context for size propagation
-interface TabBarContextValue {
-  size?: 'normal' | 'small';
-}
-
-const TabBarContext = React.createContext<TabBarContextValue>({
-  size: 'normal',
-});
-
-const useTabBarContext = () => React.useContext(TabBarContext);
-
 // TabBar container variants
 const tabBarVariants = cva('inline-flex', {
   variants: {
@@ -79,36 +68,11 @@ const moreButtonVariants = cva(
   }
 );
 
-interface TabChild {
-  value: string;
-  label: React.ReactNode;
-  disabled?: boolean | undefined;
-  asChild?: boolean;
-  childElement?: React.ReactElement<Record<string, unknown>>;
-}
-
-function extractTabChildren(children: React.ReactNode): TabChild[] {
-  const tabs: TabChild[] = [];
+function extractTabs(children: React.ReactNode) {
+  const tabs: React.ReactElement<TabProps>[] = [];
   React.Children.forEach(children, (child) => {
     if (React.isValidElement<TabProps>(child) && child.type === Tab) {
-      const {
-        value,
-        label,
-        disabled,
-        asChild,
-        children: tabChildren,
-      } = child.props;
-      const entry: TabChild = { value, label, disabled };
-
-      if (asChild) {
-        const childElement = React.Children.only(
-          tabChildren
-        ) as React.ReactElement<Record<string, unknown>>;
-        entry.asChild = true;
-        entry.childElement = childElement;
-      }
-
-      tabs.push(entry);
+      tabs.push(child);
     }
   });
   return tabs;
@@ -126,91 +90,66 @@ export const TabBar = React.forwardRef<
   React.ElementRef<typeof RadixTabs.Root>,
   TabBarProps
 >(({ className, size, children, moreLabel, ...props }, ref) => {
-  const contextValue: TabBarContextValue = size ? { size } : {};
   const effectiveSize = size ?? 'normal';
 
   const listRef = React.useRef<HTMLDivElement>(null);
   const moreRef = React.useRef<HTMLDivElement>(null);
   const tabRefs = React.useRef<Map<string, HTMLElement>>(new Map());
-  const tabWidthCache = React.useRef<Map<string, number>>(new Map());
+  // Overflow collapse: all tabs render in the DOM on mount so we can measure
+  // their widths. After the first measurement, tabs that don't fit are set to
+  // display:none and a "more" dropdown appears. A ResizeObserver recalculates
+  // on container resize. Hidden tabs keep their cached width since offsetWidth
+  // reports 0 for display:none elements.
+  const tabWidths = React.useRef<Map<string, number>>(new Map());
 
-  const tabChildren = React.useMemo(
-    () => extractTabChildren(children),
-    [children]
-  );
+  const tabs = React.useMemo(() => extractTabs(children), [children]);
 
-  const [visibleCount, setVisibleCount] = React.useState(tabChildren.length);
+  const [visibleCount, setVisibleCount] = React.useState(tabs.length);
   const [measured, setMeasured] = React.useState(false);
-
-  // Cache tab widths while they are visible (offsetWidth > 0).
-  // Hidden tabs report 0, so we keep the last known width.
-  // Also prunes entries for tabs that no longer exist.
-  const snapshotTabWidths = React.useCallback(() => {
-    const currentKeys = new Set(tabRefs.current.keys());
-
-    // Prune stale entries
-    tabWidthCache.current.forEach((_w, key) => {
-      if (!currentKeys.has(key)) {
-        tabWidthCache.current.delete(key);
-      }
-    });
-
-    // Update widths for visible tabs
-    tabRefs.current.forEach((el, value) => {
-      const w = el.offsetWidth;
-      if (w > 0) {
-        tabWidthCache.current.set(value, w);
-      }
-    });
-  }, []);
 
   const calculateVisibleTabs = React.useCallback(() => {
     const list = listRef.current;
     if (!list) return;
 
-    // Snapshot widths before calculating — visible tabs update the cache,
-    // hidden tabs keep their previously cached width.
-    snapshotTabWidths();
+    // Snapshot widths from DOM — visible tabs update, hidden tabs keep cached value
+    tabRefs.current.forEach((el, key) => {
+      const w = el.offsetWidth;
+      if (w > 0) tabWidths.current.set(key, w);
+    });
 
     const containerWidth = list.clientWidth;
     const moreButton = moreRef.current;
     const moreButtonWidth = moreButton ? moreButton.offsetWidth + 8 : 80;
 
+    // Check if all tabs fit without the more button
+    let allTabsWidth = 0;
+    for (const tab of tabs) {
+      allTabsWidth += tabWidths.current.get(tab.props.value) ?? 0;
+    }
+
+    if (allTabsWidth <= containerWidth) {
+      setVisibleCount(tabs.length);
+      setMeasured(true);
+      return;
+    }
+
+    // Not all fit — calculate how many fit alongside the more button
     let totalWidth = 0;
     let fitCount = 0;
 
-    for (const tab of tabChildren) {
-      const tabWidth = tabWidthCache.current.get(tab.value);
-      if (tabWidth == null) continue;
-      const newTotal = totalWidth + tabWidth;
-
-      if (fitCount < tabChildren.length - 1) {
-        // Not the last tab: must also fit the "more" button
-        if (newTotal + moreButtonWidth <= containerWidth) {
-          totalWidth = newTotal;
-          fitCount++;
-        } else {
-          break;
-        }
+    for (const tab of tabs) {
+      const tabWidth = tabWidths.current.get(tab.props.value) ?? 0;
+      if (totalWidth + tabWidth + moreButtonWidth <= containerWidth) {
+        totalWidth += tabWidth;
+        fitCount++;
       } else {
-        // Last tab: no "more" button needed if all fit
-        if (newTotal <= containerWidth) {
-          totalWidth = newTotal;
-          fitCount++;
-        } else {
-          break;
-        }
+        break;
       }
     }
 
-    // If only 0 tabs fit, show at least 1
-    if (fitCount === 0 && tabChildren.length > 0) {
-      fitCount = 1;
-    }
-
-    setVisibleCount(fitCount);
+    setVisibleCount(Math.max(fitCount, 1));
     setMeasured(true);
-  }, [tabChildren, snapshotTabWidths]);
+  }, [tabs]);
 
   React.useEffect(() => {
     const list = listRef.current;
@@ -226,122 +165,102 @@ export const TabBar = React.forwardRef<
     return () => observer.disconnect();
   }, [calculateVisibleTabs]);
 
-  const overflowTabs = tabChildren.slice(visibleCount);
+  const overflowTabs = tabs.slice(visibleCount);
   const hasOverflow = overflowTabs.length > 0;
 
   const activeValue = props.value ?? props.defaultValue;
   const activeInOverflow = overflowTabs.some(
-    (tab) => tab.value === activeValue
+    (tab) => tab.props.value === activeValue
   );
 
   const formatMoreLabel = moreLabel ?? ((count: number) => `${count} more`);
 
   return (
-    <TabBarContext.Provider value={contextValue}>
-      <RadixTabs.Root ref={ref} className={cn('w-full', className)} {...props}>
-        <RadixTabs.List
-          ref={listRef}
-          className={cn(tabBarVariants({ size: effectiveSize }), 'w-full')}
-          role="tablist"
-        >
-          {tabChildren.map((tab, index) => {
-            const triggerClassName = cn(
-              tabVariants({ size: effectiveSize }),
+    <RadixTabs.Root ref={ref} className={cn('w-full', className)} {...props}>
+      <RadixTabs.List
+        ref={listRef}
+        className={cn(tabBarVariants({ size: effectiveSize }), 'w-full')}
+        role="tablist"
+      >
+        {tabs.map((tab, index) =>
+          React.cloneElement(tab, {
+            key: tab.props.value,
+            size: effectiveSize,
+            ref: (el: HTMLElement | null) => {
+              if (el) {
+                tabRefs.current.set(tab.props.value, el);
+              } else {
+                tabRefs.current.delete(tab.props.value);
+              }
+            },
+            className: cn(
+              tab.props.className,
               measured && index >= visibleCount && 'hidden'
-            );
+            ),
+          } as React.Attributes & Partial<TabProps>)
+        )}
 
-            return (
-              <RadixTabs.Trigger
-                key={tab.value}
-                ref={(el: HTMLElement | null) => {
-                  if (el) {
-                    tabRefs.current.set(tab.value, el);
-                  } else {
-                    tabRefs.current.delete(tab.value);
-                  }
-                }}
-                value={tab.value}
-                disabled={tab.disabled}
-                className={!tab.asChild ? triggerClassName : undefined}
-                asChild={!!tab.asChild}
-              >
-                {tab.asChild && tab.childElement
-                  ? React.cloneElement(
-                      tab.childElement,
-                      {
-                        className: cn(
-                          triggerClassName,
-                          tab.childElement.props.className as string | undefined
-                        ),
-                      },
-                      tab.label
-                    )
-                  : tab.label}
-              </RadixTabs.Trigger>
-            );
-          })}
+        {hasOverflow && measured && (
+          <div ref={moreRef} className="inline-flex shrink-0">
+            <Dropdown>
+              <DropdownTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    moreButtonVariants({ size: effectiveSize }),
+                    activeInOverflow &&
+                      'font-bold text-[var(--chemican-green-800)]'
+                  )}
+                >
+                  <IconDotsVertical
+                    size={effectiveSize === 'small' ? 16 : 20}
+                    className="mr-xxs"
+                  />
+                  {formatMoreLabel(overflowTabs.length)}
+                </button>
+              </DropdownTrigger>
+              <DropdownContent align="end" size="sm">
+                {overflowTabs.map((tab) => {
+                  const { value, disabled, asChild, children } = tab.props;
+                  const itemClassName = cn(
+                    value === activeValue &&
+                      'font-bold text-[var(--chemican-green-800)]'
+                  );
 
-          {hasOverflow && measured && (
-            <div ref={moreRef} className="inline-flex shrink-0">
-              <Dropdown>
-                <DropdownTrigger asChild>
-                  <button
-                    type="button"
-                    className={cn(
-                      moreButtonVariants({ size: effectiveSize }),
-                      activeInOverflow &&
-                        'font-bold text-[var(--chemican-green-800)]'
-                    )}
-                  >
-                    <IconDotsVertical
-                      size={effectiveSize === 'small' ? 16 : 20}
-                      className="mr-xxs"
-                    />
-                    {formatMoreLabel(overflowTabs.length)}
-                  </button>
-                </DropdownTrigger>
-                <DropdownContent align="end" size="sm">
-                  {overflowTabs.map((tab) => {
-                    const itemClassName = cn(
-                      tab.value === activeValue &&
-                        'font-bold text-[var(--chemican-green-800)]'
-                    );
-
-                    if (tab.asChild && tab.childElement) {
-                      return (
-                        <DropdownItem
-                          key={tab.value}
-                          disabled={tab.disabled ?? false}
-                          asChild
-                          className={itemClassName}
-                        >
-                          {React.cloneElement(tab.childElement, {}, tab.label)}
-                        </DropdownItem>
-                      );
-                    }
-
+                  if (asChild && React.isValidElement(children)) {
                     return (
                       <DropdownItem
-                        key={tab.value}
-                        disabled={tab.disabled ?? false}
-                        onSelect={() => {
-                          if (props.onValueChange) {
-                            props.onValueChange(tab.value);
-                          }
-                        }}
+                        key={value}
+                        disabled={disabled ?? false}
+                        asChild
                         className={itemClassName}
                       >
-                        {tab.label}
+                        {children}
                       </DropdownItem>
                     );
-                  })}
-                </DropdownContent>
-              </Dropdown>
-            </div>
-          )}
-        </RadixTabs.List>
-      </RadixTabs.Root>
-    </TabBarContext.Provider>
+                  }
+
+                  return (
+                    <DropdownItem
+                      key={value}
+                      disabled={disabled ?? false}
+                      onSelect={() => {
+                        if (props.onValueChange) {
+                          props.onValueChange(value);
+                        }
+                      }}
+                      className={itemClassName}
+                    >
+                      {children}
+                    </DropdownItem>
+                  );
+                })}
+              </DropdownContent>
+            </Dropdown>
+          </div>
+        )}
+      </RadixTabs.List>
+    </RadixTabs.Root>
   );
 });
 
@@ -350,26 +269,20 @@ TabBar.displayName = 'TabBar';
 // Tab Component
 export interface TabProps
   extends React.ComponentPropsWithoutRef<typeof RadixTabs.Trigger>,
-    VariantProps<typeof tabVariants> {
-  label: React.ReactNode;
-}
+    VariantProps<typeof tabVariants> {}
 
 export const Tab = React.forwardRef<
   React.ElementRef<typeof RadixTabs.Trigger>,
   TabProps
->(({ className, size, label, disabled, ...props }, ref) => {
-  const { size: contextSize } = useTabBarContext();
-  const effectiveSize = size ?? contextSize;
+>(({ className, size, ...props }, ref) => {
+  const effectiveSize = size ?? 'normal';
 
   return (
     <RadixTabs.Trigger
       ref={ref}
       className={cn(tabVariants({ size: effectiveSize }), className)}
-      disabled={disabled}
       {...props}
-    >
-      {label}
-    </RadixTabs.Trigger>
+    />
   );
 });
 

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -2,8 +2,15 @@ import React from 'react';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 import { Tabs as RadixTabs } from 'radix-ui';
+import { IconDotsVertical } from '@tabler/icons-react';
 
 import { cn } from '../../lib/utils';
+import {
+  Dropdown,
+  DropdownTrigger,
+  DropdownContent,
+  DropdownItem,
+} from '../DropdownMenu';
 
 // TabBar Context for size propagation
 interface TabBarContextValue {
@@ -34,9 +41,9 @@ const tabVariants = cva(
   `text-body-primary border-divider-default data-[state=active]:font-bold
   disabled:text-interactive-disabled after:left-0 after:h-0
   disabled:hover:after:h-0 relative inline-flex cursor-pointer items-center
-  justify-center border-b leading-[100%] tracking-[0] transition-colors
-  after:absolute after:bottom-[-1px] after:w-full after:transition-all
-  after:content-[''] hover:after:h-[2px]
+  justify-center border-b leading-[100%] tracking-[0] whitespace-nowrap
+  transition-colors after:absolute after:bottom-[-1px] after:w-full
+  after:transition-all after:content-[''] hover:after:h-[2px]
   hover:after:bg-[var(--chemican-green-800)] disabled:cursor-not-allowed
   data-[state=active]:text-[var(--chemican-green-800)]
   data-[state=active]:after:h-[2px]
@@ -54,22 +61,284 @@ const tabVariants = cva(
   }
 );
 
+// More button variants
+const moreButtonVariants = cva(
+  `text-body-primary border-divider-default relative inline-flex cursor-pointer
+  items-center justify-center border-b leading-[100%] tracking-[0]
+  whitespace-nowrap transition-colors hover:text-[var(--chemican-green-800)]`,
+  {
+    variants: {
+      size: {
+        normal: 'p-md h-12 text-lg',
+        small: 'p-sm h-9.5 text-md',
+      },
+    },
+    defaultVariants: {
+      size: 'normal',
+    },
+  }
+);
+
+interface TabChild {
+  value: string;
+  label: React.ReactNode;
+  disabled?: boolean | undefined;
+  asChild?: boolean;
+  childElement?: React.ReactElement<Record<string, unknown>>;
+}
+
+function extractTabChildren(children: React.ReactNode): TabChild[] {
+  const tabs: TabChild[] = [];
+  React.Children.forEach(children, (child) => {
+    if (React.isValidElement<TabProps>(child) && child.type === Tab) {
+      const {
+        value,
+        label,
+        disabled,
+        asChild,
+        children: tabChildren,
+      } = child.props;
+      const entry: TabChild = { value, label, disabled };
+
+      if (asChild) {
+        const childElement = React.Children.only(
+          tabChildren
+        ) as React.ReactElement<Record<string, unknown>>;
+        entry.asChild = true;
+        entry.childElement = childElement;
+      }
+
+      tabs.push(entry);
+    }
+  });
+  return tabs;
+}
+
 // TabBar Root Component
 export interface TabBarProps
   extends React.ComponentPropsWithoutRef<typeof RadixTabs.Root>,
-    VariantProps<typeof tabBarVariants> {}
+    VariantProps<typeof tabBarVariants> {
+  /** Label for the overflow "more" button. Receives the count of hidden tabs. Defaults to `(count) => \`${count} more\`` */
+  moreLabel?: (count: number) => React.ReactNode;
+}
 
 export const TabBar = React.forwardRef<
   React.ElementRef<typeof RadixTabs.Root>,
   TabBarProps
->(({ className, size, children, ...props }, ref) => {
+>(({ className, size, children, moreLabel, ...props }, ref) => {
   const contextValue: TabBarContextValue = size ? { size } : {};
+  const effectiveSize = size ?? 'normal';
+
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const moreRef = React.useRef<HTMLDivElement>(null);
+  const tabRefs = React.useRef<Map<string, HTMLElement>>(new Map());
+  const tabWidthCache = React.useRef<Map<string, number>>(new Map());
+
+  const tabChildren = React.useMemo(
+    () => extractTabChildren(children),
+    [children]
+  );
+
+  const [visibleCount, setVisibleCount] = React.useState(tabChildren.length);
+  const [measured, setMeasured] = React.useState(false);
+
+  // Cache tab widths while they are visible (offsetWidth > 0).
+  // Hidden tabs report 0, so we keep the last known width.
+  // Also prunes entries for tabs that no longer exist.
+  const snapshotTabWidths = React.useCallback(() => {
+    const currentKeys = new Set(tabRefs.current.keys());
+
+    // Prune stale entries
+    tabWidthCache.current.forEach((_w, key) => {
+      if (!currentKeys.has(key)) {
+        tabWidthCache.current.delete(key);
+      }
+    });
+
+    // Update widths for visible tabs
+    tabRefs.current.forEach((el, value) => {
+      const w = el.offsetWidth;
+      if (w > 0) {
+        tabWidthCache.current.set(value, w);
+      }
+    });
+  }, []);
+
+  const calculateVisibleTabs = React.useCallback(() => {
+    const list = listRef.current;
+    if (!list) return;
+
+    // Snapshot widths before calculating — visible tabs update the cache,
+    // hidden tabs keep their previously cached width.
+    snapshotTabWidths();
+
+    const containerWidth = list.clientWidth;
+    const moreButton = moreRef.current;
+    const moreButtonWidth = moreButton ? moreButton.offsetWidth + 8 : 80;
+
+    let totalWidth = 0;
+    let fitCount = 0;
+
+    for (const tab of tabChildren) {
+      const tabWidth = tabWidthCache.current.get(tab.value);
+      if (tabWidth == null) continue;
+      const newTotal = totalWidth + tabWidth;
+
+      if (fitCount < tabChildren.length - 1) {
+        // Not the last tab: must also fit the "more" button
+        if (newTotal + moreButtonWidth <= containerWidth) {
+          totalWidth = newTotal;
+          fitCount++;
+        } else {
+          break;
+        }
+      } else {
+        // Last tab: no "more" button needed if all fit
+        if (newTotal <= containerWidth) {
+          totalWidth = newTotal;
+          fitCount++;
+        } else {
+          break;
+        }
+      }
+    }
+
+    // If only 0 tabs fit, show at least 1
+    if (fitCount === 0 && tabChildren.length > 0) {
+      fitCount = 1;
+    }
+
+    setVisibleCount(fitCount);
+    setMeasured(true);
+  }, [tabChildren, snapshotTabWidths]);
+
+  React.useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+
+    const observer = new ResizeObserver(() => {
+      calculateVisibleTabs();
+    });
+
+    observer.observe(list);
+    calculateVisibleTabs();
+
+    return () => observer.disconnect();
+  }, [calculateVisibleTabs]);
+
+  const overflowTabs = tabChildren.slice(visibleCount);
+  const hasOverflow = overflowTabs.length > 0;
+
+  const activeValue = props.value ?? props.defaultValue;
+  const activeInOverflow = overflowTabs.some(
+    (tab) => tab.value === activeValue
+  );
+
+  const formatMoreLabel = moreLabel ?? ((count: number) => `${count} more`);
 
   return (
     <TabBarContext.Provider value={contextValue}>
       <RadixTabs.Root ref={ref} className={cn('w-full', className)} {...props}>
-        <RadixTabs.List className={cn(tabBarVariants({ size }))} role="tablist">
-          {children}
+        <RadixTabs.List
+          ref={listRef}
+          className={cn(tabBarVariants({ size: effectiveSize }), 'w-full')}
+          role="tablist"
+        >
+          {tabChildren.map((tab, index) => {
+            const triggerClassName = cn(
+              tabVariants({ size: effectiveSize }),
+              measured && index >= visibleCount && 'hidden'
+            );
+
+            return (
+              <RadixTabs.Trigger
+                key={tab.value}
+                ref={(el: HTMLElement | null) => {
+                  if (el) {
+                    tabRefs.current.set(tab.value, el);
+                  } else {
+                    tabRefs.current.delete(tab.value);
+                  }
+                }}
+                value={tab.value}
+                disabled={tab.disabled}
+                className={!tab.asChild ? triggerClassName : undefined}
+                asChild={!!tab.asChild}
+              >
+                {tab.asChild && tab.childElement
+                  ? React.cloneElement(
+                      tab.childElement,
+                      {
+                        className: cn(
+                          triggerClassName,
+                          tab.childElement.props.className as string | undefined
+                        ),
+                      },
+                      tab.label
+                    )
+                  : tab.label}
+              </RadixTabs.Trigger>
+            );
+          })}
+
+          {hasOverflow && measured && (
+            <div ref={moreRef} className="inline-flex shrink-0">
+              <Dropdown>
+                <DropdownTrigger asChild>
+                  <button
+                    type="button"
+                    className={cn(
+                      moreButtonVariants({ size: effectiveSize }),
+                      activeInOverflow &&
+                        'font-bold text-[var(--chemican-green-800)]'
+                    )}
+                  >
+                    <IconDotsVertical
+                      size={effectiveSize === 'small' ? 16 : 20}
+                      className="mr-xxs"
+                    />
+                    {formatMoreLabel(overflowTabs.length)}
+                  </button>
+                </DropdownTrigger>
+                <DropdownContent align="end" size="sm">
+                  {overflowTabs.map((tab) => {
+                    const itemClassName = cn(
+                      tab.value === activeValue &&
+                        'font-bold text-[var(--chemican-green-800)]'
+                    );
+
+                    if (tab.asChild && tab.childElement) {
+                      return (
+                        <DropdownItem
+                          key={tab.value}
+                          disabled={tab.disabled ?? false}
+                          asChild
+                          className={itemClassName}
+                        >
+                          {React.cloneElement(tab.childElement, {}, tab.label)}
+                        </DropdownItem>
+                      );
+                    }
+
+                    return (
+                      <DropdownItem
+                        key={tab.value}
+                        disabled={tab.disabled ?? false}
+                        onSelect={() => {
+                          if (props.onValueChange) {
+                            props.onValueChange(tab.value);
+                          }
+                        }}
+                        className={itemClassName}
+                      >
+                        {tab.label}
+                      </DropdownItem>
+                    );
+                  })}
+                </DropdownContent>
+              </Dropdown>
+            </div>
+          )}
         </RadixTabs.List>
       </RadixTabs.Root>
     </TabBarContext.Provider>


### PR DESCRIPTION
## Issue information

Related: https://www.notion.so/Overflow-issues-32c68a0d1d7a80bfbd0ae2609383aa2e?v=31968a0d1d7a805c897d000c03a1ef62&source=copy_link

## Overview

Adds responsive overflow handling to the TabBar component. Tabs that don't fit the container width are automatically collapsed into a dropdown menu with a "x more" button, using ResizeObserver for dynamic resize detection.
It also simplifies the component by removing the `label` prop and requiring to always use the `children` prop instead. Because of that, the change is not fully backwards compatible, since the `label` props need to be removed and the label placed into the children.

## Steps to Test

- Open Storybook and navigate to Components/TabBar
- Check the `Overflow`, `OverflowWithActiveInDropdown`, and `OverflowCustomLabel` stories
- Resize the browser window to see tabs dynamically move in/out of the dropdown
- Verify selecting a tab from the dropdown activates it

## Additional Information

- New `moreLabel` prop allows customizing the overflow button label (e.g. for i18n)
- Active tab in overflow highlights the "more" button
- Tab labels use `whitespace-nowrap` to prevent wrapping
- Supports `asChild` tabs in the overflow dropdown