### PR TITLE
feat(callout): Add paid variant and remove size prop

### DIFF
--- a/src/components/Callout/Callout.stories.tsx
+++ b/src/components/Callout/Callout.stories.tsx
@@ -4,6 +4,7 @@ import {
   IconInfoCircleFilled,
   IconCircleCheckFilled,
   IconAlertTriangleFilled,
+  IconLockFilled,
   IconX,
 } from '@tabler/icons-react';
 
@@ -19,6 +20,7 @@ const iconMap = {
   IconInfoCircleFilled,
   IconCircleCheckFilled,
   IconAlertTriangleFilled,
+  IconLockFilled,
   IconX,
   None: undefined,
 };
@@ -37,12 +39,7 @@ const meta: Meta<StoryArgs> = {
     },
     intent: {
       control: { type: 'select' },
-      options: ['info', 'success', 'warning', 'alert'],
-      table: { category: 'Appearance' },
-    },
-    size: {
-      control: { type: 'select' },
-      options: ['default', 'large'],
+      options: ['info', 'success', 'warning', 'alert', 'paid'],
       table: { category: 'Appearance' },
     },
     icon: {
@@ -88,7 +85,7 @@ export const Default: StoryFn<StoryArgs> = (args) => {
 Default.args = {
   title: '見出しテキスト',
   intent: 'info',
-  size: 'default',
+
   showAction: true,
   actionLabel: 'ラベル',
 };
@@ -102,7 +99,6 @@ WithDescription.args = {
   description:
     'ファイル形式はPDF(.pdf)です。Excel, Word, PNG, ZIP, docx等のファイル形式は正常に登録できません。アップロードできるファイル容量は、1ファイルあたり最大10MBです。',
   intent: 'info',
-  size: 'default',
 };
 
 export const WithAction: StoryFn<typeof Callout> = (args) => (
@@ -116,7 +112,6 @@ WithAction.args = {
     onClick: () => alert('Action clicked!'),
   },
   intent: 'info',
-  size: 'default',
 };
 
 export const WithDescriptionAndAction: StoryFn<typeof Callout> = (args) => (
@@ -132,7 +127,6 @@ WithDescriptionAndAction.args = {
     onClick: () => alert('Action clicked!'),
   },
   intent: 'info',
-  size: 'default',
 };
 
 export const Success: StoryFn<typeof Callout> = (args) => <Callout {...args} />;
@@ -141,7 +135,6 @@ Success.args = {
   title: '成功しました',
   description: 'ファイルのアップロードが完了しました。',
   intent: 'success',
-  size: 'default',
 };
 
 export const Warning: StoryFn<typeof Callout> = (args) => <Callout {...args} />;
@@ -151,7 +144,6 @@ Warning.args = {
   description:
     'こちらの設定を変更すると、既存のデータに影響を与える可能性があります。',
   intent: 'warning',
-  size: 'default',
 };
 
 export const Alert: StoryFn<typeof Callout> = (args) => <Callout {...args} />;
@@ -161,20 +153,27 @@ Alert.args = {
   description:
     'システムエラーが発生しました。しばらくしてから再度お試しください。',
   intent: 'alert',
-  size: 'default',
+};
+
+export const Paid: StoryFn<typeof Callout> = (args) => <Callout {...args} />;
+
+Paid.args = {
+  title: '見出しテキスト',
+  description:
+    'テキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキストテキスト',
+  intent: 'paid',
 };
 
 export const AllVariants: StoryFn<typeof Callout> = () => (
   <div className="space-y-4">
-    <Callout title="Info Callout" intent="info" size="large" />
-    <Callout title="Success Callout" intent="success" size="large" />
-    <Callout title="Warning Callout" intent="warning" size="large" />
-    <Callout title="Alert Callout" intent="alert" size="large" />
-    <Callout title="Large Info Callout" intent="info" size="large" />
+    <Callout title="Info Callout" intent="info" />
+    <Callout title="Success Callout" intent="success" />
+    <Callout title="Warning Callout" intent="warning" />
+    <Callout title="Alert Callout" intent="alert" />
+    <Callout title="Paid Callout" intent="paid" />
     <Callout
       title="With Action"
       intent="info"
-      size="large"
       action={{ label: 'ラベル', onClick: () => {} }}
     />
   </div>

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -4,6 +4,7 @@ import { cva } from 'class-variance-authority';
 import {
   IconInfoCircleFilled,
   IconCircleCheckFilled,
+  IconLockFilled,
 } from '@tabler/icons-react';
 import type { TablerIcon } from '@tabler/icons-react';
 
@@ -12,7 +13,7 @@ import type { IconProp } from '../../lib/utils';
 import { cn, renderIcon } from '../../lib/utils';
 
 const calloutVariants = cva(
-  'rounded-sm gap-xxs flex items-start overflow-hidden border',
+  'rounded-sm gap-xxs py-sm px-md flex items-start overflow-hidden border',
   {
     variants: {
       intent: {
@@ -20,61 +21,57 @@ const calloutVariants = cva(
         success: 'bg-surface-success border-surface-success',
         warning: 'bg-surface-warning border-surface-warning',
         alert: 'bg-surface-alert border-surface-alert',
-      },
-      size: {
-        default: 'pt-xs pr-sm pb-xs pl-xs',
-        large: 'pt-sm pr-lg pb-sm pl-md',
+        paid: 'bg-surface-primary border-surface-success',
       },
     },
     defaultVariants: {
       intent: 'info',
-      size: 'default',
     },
   }
 );
 
-const iconVariants = cva('shrink-0', {
+const iconVariants = cva('size-5 shrink-0', {
   variants: {
     intent: {
       info: 'text-shape-status-info',
       success: 'text-shape-status-success',
       warning: 'text-shape-status-warning',
       alert: 'text-shape-status-alert',
-    },
-    size: {
-      default: 'size-5',
-      large: 'size-5',
+      paid: 'text-shape-status-success',
     },
   },
   defaultVariants: {
     intent: 'info',
-    size: 'default',
   },
 });
 
-const titleVariants = cva('text-body-primary font-bold text-md');
+const titleVariants = cva('font-bold text-md', {
+  variants: {
+    intent: {
+      info: 'text-body-primary',
+      success: 'text-body-primary',
+      warning: 'text-body-primary',
+      alert: 'text-body-primary',
+      paid: 'text-body-success',
+    },
+  },
+  defaultVariants: {
+    intent: 'info',
+  },
+});
 
 const descriptionVariants = cva(
   'text-body-primary font-normal leading-6 text-md'
 );
 
-const contentVariants = cva('min-w-0 flex flex-1 flex-col', {
-  variants: {
-    size: {
-      default: 'gap-xxxs',
-      large: 'gap-xxs',
-    },
-  },
-  defaultVariants: {
-    size: 'default',
-  },
-});
+const contentVariants = cva('min-w-0 gap-xxxs flex flex-1 flex-col');
 
 const intentIcons: Record<string, TablerIcon> = {
   info: IconInfoCircleFilled,
   success: IconCircleCheckFilled,
   warning: IconInfoCircleFilled,
   alert: IconInfoCircleFilled,
+  paid: IconLockFilled,
 };
 
 export interface CalloutProps
@@ -95,7 +92,6 @@ export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
     {
       className,
       intent = 'info',
-      size = 'default',
       title,
       description,
       children,
@@ -110,17 +106,20 @@ export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
     return (
       <div
         ref={ref}
-        className={cn(calloutVariants({ intent, size }), className)}
+        className={cn(calloutVariants({ intent }), className)}
         {...props}
       >
-        <div className={cn(iconVariants({ intent, size }), 'top-0.5 relative')}>
-          {renderIcon(IconComponent, { className: 'size-full' })}
-        </div>
-
-        <div className={cn(contentVariants({ size }))}>
+        <div className={cn(contentVariants())}>
           {title && (
             <div className="flex items-center justify-between">
-              <div className={cn(titleVariants())}>{title}</div>
+              <div className="gap-xxs flex">
+                <div
+                  className={cn(iconVariants({ intent }), 'top-0.5 relative')}
+                >
+                  {renderIcon(IconComponent, { className: 'size-full' })}
+                </div>
+                <div className={cn(titleVariants({ intent }))}>{title}</div>
+              </div>
               {action && (
                 <TextLink
                   onClick={action.onClick}


### PR DESCRIPTION
## Issue information
- [Figma design](https://www.figma.com/design/7xn3jw9adzh0eUz5P7piPy/%E3%82%B3%E3%83%BC%E3%83%AB%E3%82%A2%E3%82%A6%E3%83%88%E6%94%B9%E4%BF%AE?node-id=31534-41622&t=KN44bkCBRkUPFWna-4)
<img width="982" height="112" alt="image" src="https://github.com/user-attachments/assets/d5fbf3ea-ea15-42cb-8d69-690200585b1b" />

## Overview
- Add a new `paid` intent variant to the Callout component with white background, success-colored border, lock icon (`IconLockFilled`), and success-colored title text
- Remove the `size` variant prop, keeping only the small size as the single default

## Dependencies
- Components consuming `Callout` with an explicit `size` prop will need to remove it

## Steps to Test
- Open Storybook and navigate to Components/Callout
- Verify the new "Paid" story renders with a lock icon, white background, teal border, and teal title text
- Verify all other intent variants still render correctly
- Confirm the `size` prop is no longer available in Storybook controls