### PR TITLE
refactor(DataSheet): [FTD-59] Add proper a11y for DataSheet

### DIFF
--- a/src/components/DataSheet/DataSheet.stories.tsx
+++ b/src/components/DataSheet/DataSheet.stories.tsx
@@ -3,6 +3,8 @@ import type { Meta, StoryFn } from 'storybook/react-vite';
 import { IconPlus } from '@tabler/icons-react';
 
 import { Accordion } from '../Accordion';
+import { TextArea } from '../TextArea/TextArea';
+import { TextField } from '../TextField/TextField';
 
 import { DataSheet } from './DataSheet';
 
@@ -609,3 +611,36 @@ export const SectionDataExampleWithinAccordion: Story = () => (
     </Accordion>
   </div>
 );
+
+export const KeyValueWithFormFields: Story = () => (
+  <DataSheet className="w-140">
+    <DataSheet.Section>
+      <DataSheet.KeyValue label="製品名">
+        <TextField defaultValue="塩酸溶液" />
+      </DataSheet.KeyValue>
+      <DataSheet.KeyValue label="CAS番号">
+        <TextField defaultValue="7647-01-0" />
+      </DataSheet.KeyValue>
+      <DataSheet.KeyValue label="備考">
+        <TextArea
+          defaultValue="取り扱いには十分注意してください。"
+          showCharacterLimit={false}
+        />
+      </DataSheet.KeyValue>
+      <DataSheet.KeyValue orientation="horizontal" label="推奨用途">
+        <TextField defaultValue="研究用" />
+      </DataSheet.KeyValue>
+    </DataSheet.Section>
+  </DataSheet>
+);
+KeyValueWithFormFields.parameters = {
+  docs: {
+    description: {
+      story:
+        'DataSheet.KeyValue wires its label to child form fields via ' +
+        '`aria-labelledby`, so screen readers announce the label and ' +
+        '`findByLabelText` queries resolve correctly. Inspect any input — ' +
+        'its `aria-labelledby` points at the sibling label `<div>`.',
+    },
+  },
+};

--- a/src/components/DataSheet/DataSheet.stories.tsx
+++ b/src/components/DataSheet/DataSheet.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryFn } from 'storybook/react-vite';
 import { IconPlus } from '@tabler/icons-react';
 
 import { Accordion } from '../Accordion';
+import { DatePicker } from '../DatePicker/DatePicker';
 import { TextArea } from '../TextArea/TextArea';
 import { TextField } from '../TextField/TextField';
 
@@ -626,6 +627,9 @@ export const KeyValueWithFormFields: Story = () => (
           defaultValue="取り扱いには十分注意してください。"
           showCharacterLimit={false}
         />
+      </DataSheet.KeyValue>
+      <DataSheet.KeyValue label="SDS改訂日">
+        <DatePicker defaultValue={new Date('2025-01-08')} />
       </DataSheet.KeyValue>
       <DataSheet.KeyValue orientation="horizontal" label="推奨用途">
         <TextField defaultValue="研究用" />

--- a/src/components/DataSheet/DataSheet.tsx
+++ b/src/components/DataSheet/DataSheet.tsx
@@ -240,23 +240,42 @@ export interface DataSheetKeyValueProps
 const DataSheetKeyValue = React.forwardRef<
   HTMLDivElement,
   DataSheetKeyValueProps
->(({ className, label, orientation, spacing, children, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      dataSheetKeyValueVariants({ orientation, spacing }),
-      className
-    )}
-    {...props}
-  >
-    <div className={cn(dataSheetKeyValueLabelVariants({ orientation }))}>
-      {label}
+>(({ className, label, orientation, spacing, children, ...props }, ref) => {
+  const labelId = React.useId();
+
+  const labelledChildren = React.Children.map(children, (child) => {
+    if (!React.isValidElement(child)) return child;
+    const childProps = child.props as { 'aria-labelledby'?: string };
+    const existing = childProps['aria-labelledby'];
+    return React.cloneElement(
+      child as React.ReactElement<Record<string, unknown>>,
+      {
+        'aria-labelledby': existing ? `${existing} ${labelId}` : labelId,
+      }
+    );
+  });
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        dataSheetKeyValueVariants({ orientation, spacing }),
+        className
+      )}
+      {...props}
+    >
+      <div
+        id={labelId}
+        className={cn(dataSheetKeyValueLabelVariants({ orientation }))}
+      >
+        {label}
+      </div>
+      <div className={cn(dataSheetKeyValueValueVariants({ orientation }))}>
+        {labelledChildren}
+      </div>
     </div>
-    <div className={cn(dataSheetKeyValueValueVariants({ orientation }))}>
-      {children}
-    </div>
-  </div>
-));
+  );
+});
 DataSheetKeyValue.displayName = 'DataSheetKeyValue';
 
 export type DataSheetItemType = string | number | object;

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -135,6 +135,7 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       onOpenChange,
       side = 'bottom',
       locale = 'ja',
+      ...rest
     },
     ref
   ) => {
@@ -216,6 +217,7 @@ export const DatePicker = React.forwardRef<HTMLInputElement, DatePickerProps>(
       <Popover.Root open={isOpen} onOpenChange={handleOpenChange}>
         <Popover.Trigger asChild>
           <TextField
+            {...rest}
             ref={ref}
             type="text"
             readOnly


### PR DESCRIPTION
## Issue information
`DataSheet.KeyValue` was rendering its label in a plain `<div>` with no semantic connection to child form elements.
This means screen readers can't associate labels with inputs, and `cy.findByLabelText()` was failing, forcing e2e tests to use brittle DOM traversal like `cy.contains(label).parent().find('textarea')`.

The goal of this PR is to add proper aria-labelledby support.

## Note
- `React.useId()` generates a stable `labelId` per `DataSheet.KeyValue` instance.
The label `<div>` receives `id={labelId}`
Direct children are cloned with `aria-labelledby={labelId}` injected (preserving any existing `aria-labelledby` by space-joining).
- Fix DatePicker to forward unknown props: destructure `...rest` and pass it to the inner `TextField`. That fix covers `aria-describedby`, `id`, `name`, etc...
