### PR TITLE
feat(Tag): Add secondary variant and icon support

### DIFF
--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -27,6 +27,9 @@ const meta: Meta<typeof Tag> = {
     selected: {
       control: 'boolean',
     },
+    disabled: {
+      control: 'boolean',
+    },
     onRemove: {
       control: 'boolean',
       defaultValue: false,
@@ -104,6 +107,31 @@ SecondaryWithIcon.args = {
   icon: IconStar,
 };
 
+export const DisabledPrimary = TagTemplate.bind({});
+DisabledPrimary.args = {
+  children: '無効',
+  colorCode: 8,
+  variant: 'primary',
+  disabled: true,
+};
+
+export const DisabledSecondary = TagTemplate.bind({});
+DisabledSecondary.args = {
+  children: '無効',
+  colorCode: 8,
+  variant: 'secondary',
+  disabled: true,
+};
+
+export const DisabledWithIcon = TagTemplate.bind({});
+DisabledWithIcon.args = {
+  children: '無効',
+  colorCode: 8,
+  variant: 'secondary',
+  icon: IconStar,
+  disabled: true,
+};
+
 export const ColorCodeShowcase: StoryFn<{
   selected?: boolean;
   variant?: 'primary' | 'secondary';
@@ -173,6 +201,22 @@ export const VariantComparison: StoryFn = () => {
           ))}
         </div>
       </div>
+      <div>
+        <h3 className="text-body-primary mb-xs text-sm font-medium">
+          Disabled States
+        </h3>
+        <div className="gap-2 flex flex-wrap">
+          <Tag colorCode={8} variant="primary" disabled>
+            Primary 無効
+          </Tag>
+          <Tag colorCode={8} variant="secondary" disabled>
+            Secondary 無効
+          </Tag>
+          <Tag colorCode={8} variant="secondary" icon={IconTag} disabled>
+            Icon 無効
+          </Tag>
+        </div>
+      </div>
     </div>
   );
 };
@@ -182,7 +226,7 @@ export const WithIconShowcase: StoryFn = () => {
     <div className="gap-md flex flex-col">
       <div>
         <h3 className="text-body-primary mb-xs text-sm font-medium">
-          Primary with Icons
+          Primary with Icons (icon inherits text color)
         </h3>
         <div className="gap-2 flex flex-wrap">
           <Tag colorCode={8} icon={IconTag}>
@@ -194,11 +238,14 @@ export const WithIconShowcase: StoryFn = () => {
           <Tag colorCode={2} icon={IconHeart}>
             いいね
           </Tag>
+          <Tag colorCode={25} icon={IconTag}>
+            Cyan
+          </Tag>
         </div>
       </div>
       <div>
         <h3 className="text-body-primary mb-xs text-sm font-medium">
-          Secondary with Icons
+          Secondary with Icons (icon uses distinct accent color)
         </h3>
         <div className="gap-2 flex flex-wrap">
           <Tag colorCode={8} variant="secondary" icon={IconTag}>
@@ -209,6 +256,22 @@ export const WithIconShowcase: StoryFn = () => {
           </Tag>
           <Tag colorCode={2} variant="secondary" icon={IconHeart}>
             いいね
+          </Tag>
+          <Tag colorCode={25} variant="secondary" icon={IconTag}>
+            Cyan
+          </Tag>
+        </div>
+      </div>
+      <div>
+        <h3 className="text-body-primary mb-xs text-sm font-medium">
+          Disabled with Icons
+        </h3>
+        <div className="gap-2 flex flex-wrap">
+          <Tag colorCode={8} variant="primary" icon={IconTag} disabled>
+            Primary 無効
+          </Tag>
+          <Tag colorCode={8} variant="secondary" icon={IconTag} disabled>
+            Secondary 無効
           </Tag>
         </div>
       </div>

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -107,6 +107,14 @@ SecondaryWithIcon.args = {
   icon: IconStar,
 };
 
+export const SecondaryWithRemoveButton = TagTemplate.bind({});
+SecondaryWithRemoveButton.args = {
+  children: '削除可能',
+  colorCode: 8,
+  variant: 'secondary',
+  onRemove: () => alert('Tag removed!'),
+};
+
 export const DisabledPrimary = TagTemplate.bind({});
 DisabledPrimary.args = {
   children: '無効',

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Meta, StoryFn } from 'storybook/react-vite';
+import { IconTag, IconStar, IconHeart } from '@tabler/icons-react';
 
 import type { TagProps } from './Tag';
 import { colorCodeToTokenMap, Tag } from './Tag';
@@ -18,6 +19,10 @@ const meta: Meta<typeof Tag> = {
     size: {
       control: 'select',
       options: ['sm', 'md'],
+    },
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary'],
     },
     selected: {
       control: 'boolean',
@@ -77,9 +82,32 @@ WithCustomColors.args = {
   className: 'bg-surface-alert text-body-primary',
 };
 
-export const ColorCodeShowcase: StoryFn<{ selected?: boolean }> = ({
-  selected = false,
-}) => {
+export const WithIcon = TagTemplate.bind({});
+WithIcon.args = {
+  children: 'タグ',
+  colorCode: 8,
+  icon: IconTag,
+};
+
+export const SecondaryVariant = TagTemplate.bind({});
+SecondaryVariant.args = {
+  children: 'セカンダリ',
+  colorCode: 17,
+  variant: 'secondary',
+};
+
+export const SecondaryWithIcon = TagTemplate.bind({});
+SecondaryWithIcon.args = {
+  children: 'アイコン付き',
+  colorCode: 8,
+  variant: 'secondary',
+  icon: IconStar,
+};
+
+export const ColorCodeShowcase: StoryFn<{
+  selected?: boolean;
+  variant?: 'primary' | 'secondary';
+}> = ({ selected = false, variant = 'primary' }) => {
   // Get unique color codes and sort them
   const uniqueColorCodes = Array.from(
     new Set(colorCodeToTokenMap.map((c) => c.code))
@@ -88,7 +116,12 @@ export const ColorCodeShowcase: StoryFn<{ selected?: boolean }> = ({
   return (
     <div className="gap-2 flex flex-wrap">
       {uniqueColorCodes.map((colorCode) => (
-        <Tag key={colorCode} colorCode={colorCode} selected={selected}>
+        <Tag
+          key={colorCode}
+          colorCode={colorCode}
+          selected={selected}
+          variant={variant}
+        >
           カラー {colorCode}
         </Tag>
       ))}
@@ -98,10 +131,87 @@ export const ColorCodeShowcase: StoryFn<{ selected?: boolean }> = ({
 
 ColorCodeShowcase.args = {
   selected: false,
+  variant: 'primary',
 };
 
 ColorCodeShowcase.argTypes = {
   selected: {
     control: 'boolean',
   },
+  variant: {
+    control: 'select',
+    options: ['primary', 'secondary'],
+  },
+};
+
+export const VariantComparison: StoryFn = () => {
+  const sampleColorCodes = [1, 8, 17, 25, 33];
+
+  return (
+    <div className="gap-md flex flex-col">
+      <div>
+        <h3 className="text-body-primary mb-xs text-sm font-medium">
+          Primary Variant (accent background)
+        </h3>
+        <div className="gap-2 flex flex-wrap">
+          {sampleColorCodes.map((colorCode) => (
+            <Tag key={colorCode} colorCode={colorCode} variant="primary">
+              カラー {colorCode}
+            </Tag>
+          ))}
+        </div>
+      </div>
+      <div>
+        <h3 className="text-body-primary mb-xs text-sm font-medium">
+          Secondary Variant (neutral background)
+        </h3>
+        <div className="gap-2 flex flex-wrap">
+          {sampleColorCodes.map((colorCode) => (
+            <Tag key={colorCode} colorCode={colorCode} variant="secondary">
+              カラー {colorCode}
+            </Tag>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const WithIconShowcase: StoryFn = () => {
+  return (
+    <div className="gap-md flex flex-col">
+      <div>
+        <h3 className="text-body-primary mb-xs text-sm font-medium">
+          Primary with Icons
+        </h3>
+        <div className="gap-2 flex flex-wrap">
+          <Tag colorCode={8} icon={IconTag}>
+            タグ
+          </Tag>
+          <Tag colorCode={19} icon={IconStar}>
+            お気に入り
+          </Tag>
+          <Tag colorCode={2} icon={IconHeart}>
+            いいね
+          </Tag>
+        </div>
+      </div>
+      <div>
+        <h3 className="text-body-primary mb-xs text-sm font-medium">
+          Secondary with Icons
+        </h3>
+        <div className="gap-2 flex flex-wrap">
+          <Tag colorCode={8} variant="secondary" icon={IconTag}>
+            タグ
+          </Tag>
+          <Tag colorCode={19} variant="secondary" icon={IconStar}>
+            お気に入り
+          </Tag>
+          <Tag colorCode={2} variant="secondary" icon={IconHeart}>
+            いいね
+          </Tag>
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { cva } from 'class-variance-authority';
 
 import { ColorShapeTokens, ColorTextTokens } from '../../tokens';
-import { cn } from '../../utils';
+import { cn, renderIcon } from '../../utils';
+import type { IconProp } from '../../utils';
 
 // Mapping the color codes for user defined tag colors to our design tokens
 // Reference: https://docs.google.com/spreadsheets/d/14r5PJTfzfESsKypY2cJlR65I2-DkO4RvODa04x_s1dA
@@ -202,12 +203,13 @@ export interface TagProps {
   size?: 'sm' | 'md';
   style?: React.CSSProperties;
   selected?: boolean;
+  variant?: 'primary' | 'secondary';
+  icon?: IconProp;
 }
 
 const tagVariants = cva(
-  `gap-xxs py-xxs px-xs h-5.5 bg-shape-accent-gray-pale text-accent-gray-strong
-  inline-flex max-w-full items-center rounded-full border border-transparent
-  leading-none`,
+  `gap-xxs py-xxs px-xs h-5.5 inline-flex max-w-full items-center rounded-full
+  border border-transparent leading-none`,
   {
     variants: {
       size: {
@@ -221,10 +223,15 @@ const tagVariants = cva(
       interactive: {
         true: 'cursor-pointer select-none',
       },
+      variant: {
+        primary: '',
+        secondary: 'bg-surface-disabled',
+      },
     },
     defaultVariants: {
       size: 'md',
       selected: false,
+      variant: 'primary',
     },
   }
 );
@@ -238,6 +245,8 @@ export const Tag: React.FC<TagProps> = ({
   size = 'md',
   style,
   selected = false,
+  variant = 'primary',
+  icon,
 }) => {
   const colorMapping = colorCodeToTokenMap.find(
     (colorMap) => colorMap.code === colorCode
@@ -246,17 +255,24 @@ export const Tag: React.FC<TagProps> = ({
   return (
     <div
       className={cn(
-        tagVariants({ size, selected, interactive: Boolean(onClick) }),
+        tagVariants({ size, selected, interactive: Boolean(onClick), variant }),
         className
       )}
       style={{
-        backgroundColor: `var(${colorMapping?.backgroundColor})`,
+        // Only apply accent background for primary variant
+        // Secondary variant uses bg-surface-disabled from CVA
+        ...(variant === 'primary' && {
+          backgroundColor: `var(${colorMapping?.backgroundColor})`,
+        }),
         color: `var(${colorMapping?.textColor})`,
         ...style,
       }}
       onClick={onClick}
       role={onClick ? 'button' : undefined}
     >
+      {icon && (
+        <span className="shrink-0">{renderIcon(icon, { size: 14 })}</span>
+      )}
       <div className="truncate">{children}</div>
       {Boolean(onRemove) && (
         <button

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -265,7 +265,7 @@ const tagVariants = cva(
         secondary: 'bg-surface-disabled',
       },
       disabled: {
-        true: '',
+        true: 'text-body-disabled',
         false: '',
       },
     },
@@ -306,21 +306,10 @@ export const Tag: React.FC<TagProps> = ({
     (colorMap) => colorMap.code === colorCode
   );
 
-  // Determine text color based on variant and disabled state
-  const getTextColor = () => {
-    if (disabled) {
-      return 'var(--token-color-text-body-disabled)';
-    }
-    return `var(${colorMapping?.textColor})`;
-  };
-
-  // Determine icon color based on variant and disabled state
+  // Determine icon color based on variant
   // For secondary variant, icon uses shape color (distinct from text color)
   // For primary variant, icon inherits text color
   const getIconColor = () => {
-    if (disabled) {
-      return 'var(--token-color-shape-interactive-disabled)';
-    }
     if (variant === 'secondary') {
       return `var(${colorMapping?.iconColor})`;
     }
@@ -346,15 +335,22 @@ export const Tag: React.FC<TagProps> = ({
         ...(variant === 'primary' && {
           backgroundColor: `var(${colorMapping?.backgroundColor})`,
         }),
-        color: getTextColor(),
+        // Only apply inline color when not disabled (Tailwind class handles disabled state)
+        ...(!disabled && { color: `var(${colorMapping?.textColor})` }),
         ...style,
       }}
       onClick={disabled ? undefined : onClick}
-      role={onClick && !disabled ? 'button' : undefined}
+      role={onClick ? 'button' : undefined}
       aria-disabled={disabled || undefined}
     >
       {icon && (
-        <span className="shrink-0" style={{ color: getIconColor() }}>
+        <span
+          className={cn(
+            'shrink-0',
+            disabled && 'text-shape-interactive-disabled'
+          )}
+          style={disabled ? undefined : { color: getIconColor() }}
+        >
           {renderIcon(icon, { size: 14 })}
         </span>
       )}

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -11,171 +11,205 @@ export const colorCodeToTokenMap = [
   {
     backgroundColor: ColorShapeTokens.AccentSunSoft,
     textColor: ColorTextTokens.AccentSunStrong,
+    iconColor: ColorShapeTokens.AccentSunStrong,
     code: 19,
   },
   {
     backgroundColor: ColorShapeTokens.AccentSunPale,
     textColor: ColorTextTokens.AccentSunStrong,
+    iconColor: ColorShapeTokens.AccentSunStrong,
     code: 1,
   },
   {
     backgroundColor: ColorShapeTokens.AccentWoodSoft,
     textColor: ColorTextTokens.AccentWoodStrong,
+    iconColor: ColorShapeTokens.AccentWoodStrong,
     code: 34,
   },
   {
     backgroundColor: ColorShapeTokens.AccentWoodPale,
     textColor: ColorTextTokens.AccentWoodStrong,
+    iconColor: ColorShapeTokens.AccentWoodStrong,
     code: 16,
   },
   {
     backgroundColor: ColorShapeTokens.AccentOrangeSoft,
     textColor: ColorTextTokens.AccentOrangeStrong,
+    iconColor: ColorShapeTokens.AccentOrangeStrong,
     code: 33,
   },
   {
     backgroundColor: ColorShapeTokens.AccentOrangePale,
     textColor: ColorTextTokens.AccentOrangeStrong,
+    iconColor: ColorShapeTokens.AccentOrangeStrong,
     code: 15,
   },
   {
     backgroundColor: ColorShapeTokens.AccentYellowSoft,
     textColor: ColorTextTokens.AccentYellowStrong,
+    iconColor: ColorShapeTokens.AccentYellowStrong,
     code: 32,
   },
   {
     backgroundColor: ColorShapeTokens.AccentYellowPale,
     textColor: ColorTextTokens.AccentYellowStrong,
+    iconColor: ColorShapeTokens.AccentYellowStrong,
     code: 14,
   },
   {
     backgroundColor: ColorShapeTokens.AccentLemonSoft,
     textColor: ColorTextTokens.AccentLemonStrong,
+    iconColor: ColorShapeTokens.AccentLemonStrong,
     code: 31,
   },
   {
     backgroundColor: ColorShapeTokens.AccentLemonPale,
     textColor: ColorTextTokens.AccentLemonStrong,
+    iconColor: ColorShapeTokens.AccentLemonStrong,
     code: 13,
   },
   {
     backgroundColor: ColorShapeTokens.AccentGrassSoft,
     textColor: ColorTextTokens.AccentGrassStrong,
+    iconColor: ColorShapeTokens.AccentGrassStrong,
     code: 30,
   },
   {
     backgroundColor: ColorShapeTokens.AccentGrassPale,
     textColor: ColorTextTokens.AccentGrassStrong,
+    iconColor: ColorShapeTokens.AccentGrassStrong,
     code: 12,
   },
   {
     backgroundColor: ColorShapeTokens.AccentLimeSoft,
     textColor: ColorTextTokens.AccentLimeStrong,
+    iconColor: ColorShapeTokens.AccentLimeStrong,
     code: 29,
   },
   {
     backgroundColor: ColorShapeTokens.AccentLimePale,
     textColor: ColorTextTokens.AccentLimeStrong,
+    iconColor: ColorShapeTokens.AccentLimeStrong,
     code: 11,
   },
   {
     backgroundColor: ColorShapeTokens.AccentGreenSoft,
     textColor: ColorTextTokens.AccentGreenStrong,
+    iconColor: ColorShapeTokens.AccentGreenStrong,
     code: 27,
   },
   {
     backgroundColor: ColorShapeTokens.AccentGreenPale,
     textColor: ColorTextTokens.AccentGreenStrong,
+    iconColor: ColorShapeTokens.AccentGreenStrong,
     code: 9,
   },
   {
     backgroundColor: ColorShapeTokens.AccentPeacockSoft,
     textColor: ColorTextTokens.AccentPeacockStrong,
+    iconColor: ColorShapeTokens.AccentPeacockStrong,
     code: 26,
   },
   {
     backgroundColor: ColorShapeTokens.AccentPeacockPale,
     textColor: ColorTextTokens.AccentPeacockStrong,
+    iconColor: ColorShapeTokens.AccentPeacockStrong,
     code: 8,
   },
   {
     backgroundColor: ColorShapeTokens.AccentCyanSoft,
     textColor: ColorTextTokens.AccentCyanStrong,
+    iconColor: ColorShapeTokens.AccentCyanStrong,
     code: 25,
   },
   {
     backgroundColor: ColorShapeTokens.AccentCyanPale,
     textColor: ColorTextTokens.AccentCyanStrong,
+    iconColor: ColorShapeTokens.AccentCyanStrong,
     code: 7,
   },
   {
     backgroundColor: ColorShapeTokens.AccentSkySoft,
     textColor: ColorTextTokens.AccentSkyStrong,
+    iconColor: ColorShapeTokens.AccentSkyStrong,
     code: 24,
   },
   {
     backgroundColor: ColorShapeTokens.AccentSkyPale,
     textColor: ColorTextTokens.AccentSkyStrong,
+    iconColor: ColorShapeTokens.AccentSkyStrong,
     code: 6,
   },
   {
     backgroundColor: ColorShapeTokens.AccentSeaSoft,
     textColor: ColorTextTokens.AccentSeaStrong,
+    iconColor: ColorShapeTokens.AccentSeaStrong,
     code: 23,
   },
   {
     backgroundColor: ColorShapeTokens.AccentSeaPale,
     textColor: ColorTextTokens.AccentSeaStrong,
+    iconColor: ColorShapeTokens.AccentSeaStrong,
     code: 5,
   },
   {
     backgroundColor: ColorShapeTokens.AccentVioletSoft,
     textColor: ColorTextTokens.AccentVioletStrong,
+    iconColor: ColorShapeTokens.AccentVioletStrong,
     code: 22,
   },
   {
     backgroundColor: ColorShapeTokens.AccentVioletPale,
     textColor: ColorTextTokens.AccentVioletStrong,
+    iconColor: ColorShapeTokens.AccentVioletStrong,
     code: 4,
   },
   {
     backgroundColor: ColorShapeTokens.AccentPurpleSoft,
     textColor: ColorTextTokens.AccentPurpleStrong,
+    iconColor: ColorShapeTokens.AccentPurpleStrong,
     code: 21,
   },
   {
     backgroundColor: ColorShapeTokens.AccentPurplePale,
     textColor: ColorTextTokens.AccentPurpleStrong,
+    iconColor: ColorShapeTokens.AccentPurpleStrong,
     code: 3,
   },
   {
     backgroundColor: ColorShapeTokens.AccentMagentaSoft,
     textColor: ColorTextTokens.AccentMagentaStrong,
+    iconColor: ColorShapeTokens.AccentMagentaStrong,
     code: 20,
   },
   {
     backgroundColor: ColorShapeTokens.AccentMagentaPale,
     textColor: ColorTextTokens.AccentMagentaStrong,
+    iconColor: ColorShapeTokens.AccentMagentaStrong,
     code: 2,
   },
   {
     backgroundColor: ColorShapeTokens.AccentCharcoalSoft,
     textColor: ColorTextTokens.AccentCharchoalStrong,
+    iconColor: ColorShapeTokens.AccentCharcoalStrong,
     code: 35,
   },
   {
     backgroundColor: ColorShapeTokens.AccentCharcoalPale,
     textColor: ColorTextTokens.AccentCharchoalStrong,
+    iconColor: ColorShapeTokens.AccentCharcoalStrong,
     code: 17,
   },
   {
     backgroundColor: ColorShapeTokens.AccentGraySoft,
     textColor: ColorTextTokens.AccentGrayStrong,
+    iconColor: ColorShapeTokens.AccentGrayStrong,
     code: 36,
   },
   {
     backgroundColor: ColorShapeTokens.AccentGrayPale,
     textColor: ColorTextTokens.AccentGrayStrong,
+    iconColor: ColorShapeTokens.AccentGrayStrong,
     code: 18,
   },
 
@@ -183,11 +217,13 @@ export const colorCodeToTokenMap = [
   {
     backgroundColor: ColorShapeTokens.AccentGrayPale,
     textColor: ColorTextTokens.AccentGrayStrong,
+    iconColor: ColorShapeTokens.AccentGrayStrong,
     code: 0,
   },
   {
     backgroundColor: ColorShapeTokens.AccentBambooPale,
     textColor: ColorTextTokens.AccentBambooStrong,
+    iconColor: ColorShapeTokens.AccentBambooStrong,
     code: 10,
   },
 ] as const;
@@ -205,6 +241,7 @@ export interface TagProps {
   selected?: boolean;
   variant?: 'primary' | 'secondary';
   icon?: IconProp;
+  disabled?: boolean;
 }
 
 const tagVariants = cva(
@@ -227,11 +264,27 @@ const tagVariants = cva(
         primary: '',
         secondary: 'bg-surface-disabled',
       },
+      disabled: {
+        true: '',
+        false: '',
+      },
     },
+    compoundVariants: [
+      {
+        variant: 'secondary',
+        disabled: true,
+        className: 'bg-interactive-disabled',
+      },
+      {
+        disabled: true,
+        className: 'cursor-default',
+      },
+    ],
     defaultVariants: {
       size: 'md',
       selected: false,
       variant: 'primary',
+      disabled: false,
     },
   }
 );
@@ -247,34 +300,66 @@ export const Tag: React.FC<TagProps> = ({
   selected = false,
   variant = 'primary',
   icon,
+  disabled = false,
 }) => {
   const colorMapping = colorCodeToTokenMap.find(
     (colorMap) => colorMap.code === colorCode
   );
 
+  // Determine text color based on variant and disabled state
+  const getTextColor = () => {
+    if (disabled) {
+      return 'var(--token-color-text-body-disabled)';
+    }
+    return `var(${colorMapping?.textColor})`;
+  };
+
+  // Determine icon color based on variant and disabled state
+  // For secondary variant, icon uses shape color (distinct from text color)
+  // For primary variant, icon inherits text color
+  const getIconColor = () => {
+    if (disabled) {
+      return 'var(--token-color-shape-interactive-disabled)';
+    }
+    if (variant === 'secondary') {
+      return `var(${colorMapping?.iconColor})`;
+    }
+    // Primary variant: icon uses same color as text
+    return `var(${colorMapping?.textColor})`;
+  };
+
   return (
     <div
       className={cn(
-        tagVariants({ size, selected, interactive: Boolean(onClick), variant }),
+        tagVariants({
+          size,
+          selected: disabled ? false : selected,
+          interactive: Boolean(onClick) && !disabled,
+          variant,
+          disabled,
+        }),
         className
       )}
       style={{
         // Only apply accent background for primary variant
-        // Secondary variant uses bg-surface-disabled from CVA
+        // Secondary variant uses bg-surface-disabled from CVA (or bg-interactive-disabled when disabled)
         ...(variant === 'primary' && {
           backgroundColor: `var(${colorMapping?.backgroundColor})`,
         }),
-        color: `var(${colorMapping?.textColor})`,
+        color: getTextColor(),
         ...style,
       }}
-      onClick={onClick}
-      role={onClick ? 'button' : undefined}
+      onClick={disabled ? undefined : onClick}
+      role={onClick && !disabled ? 'button' : undefined}
+      aria-disabled={disabled || undefined}
     >
       {icon && (
-        <span className="shrink-0">{renderIcon(icon, { size: 14 })}</span>
+        <span className="shrink-0" style={{ color: getIconColor() }}>
+          {renderIcon(icon, { size: 14 })}
+        </span>
       )}
       <div className="truncate">{children}</div>
-      {Boolean(onRemove) && (
+      {Boolean(onRemove) && !disabled && (
         <button
           className={cn(
             `bg-interactive-neutral-default h-3 w-3 flex cursor-pointer


### PR DESCRIPTION
## issue information
<!--
* githubのissueタイトルとURL
* slackでのコミュニケーションログ
* Notionでの関連ドキュメントリンクなど
-->

## Overview
Add a new "secondary" variant with neutral background (bg-surface-disabled) instead of accent colors. Add icon prop support with proper rendering.

Update stories to showcase both variants with and without icons, including variant comparison and icon showcase stories.

Refer: https://www.notion.so/Use-new-secondary-tags-in-checklist-template-cards-34868a0d1d7a8084810eded8652c6f04
<!--
* 変更の理由や内容の説明
-->
## Dependencies
<!--
* 変更の影響を受けると考えられる機能や環境
-->

## Step to test
<!--
* 動作確認手順
-->

## Additional information
<!--
* 特にレビューしてほしいポイントなどの補足情報
-->
