### PR TITLE
feat(sidenavigation): Show tooltip on collapsed nav items

### DIFF
--- a/src/components/SideNavigation/SideNavigation.stories.tsx
+++ b/src/components/SideNavigation/SideNavigation.stories.tsx
@@ -172,6 +172,8 @@ export const Default: Story = {
           header={<Header />}
           footer={<Footer />}
           showCollapseButton
+          collapseLabel="メニューを閉じる"
+          expandLabel="メニューを開く"
         >
           <DefaultContent />
         </SideNavigation>
@@ -278,6 +280,8 @@ export const WithCustomLinks: Story = {
           header={<Header />}
           footer={<Footer />}
           showCollapseButton
+          collapseLabel="メニューを閉じる"
+          expandLabel="メニューを開く"
         >
           <CustomLinksContent />
         </SideNavigation>

--- a/src/components/SideNavigation/SideNavigation.stories.tsx
+++ b/src/components/SideNavigation/SideNavigation.stories.tsx
@@ -22,6 +22,8 @@ import {
   DropdownSeparator,
 } from '../DropdownMenu';
 
+import { TooltipProvider } from '../Tooltip';
+
 import { SideNavigation } from './SideNavigation';
 import { SideNavigationItem } from './SideNavigationItem';
 import { SideNavigationSection } from './SideNavigationSection';
@@ -49,6 +51,13 @@ const meta = {
     },
   },
   args: {},
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
 } satisfies Meta<typeof SideNavigation>;
 
 export default meta;
@@ -61,13 +70,13 @@ const Footer = () => {
 
   return (
     <div className="space-y-xxxs">
-      <SideNavigationItem asChild>
+      <SideNavigationItem asChild tooltipLabel="ヘルプセンター">
         <a href="#" className="gap-xs flex items-center">
           <IconInfoCircle size={16} className="shrink-0" />
           {!isCollapsed && 'ヘルプセンター'}
         </a>
       </SideNavigationItem>
-      <SideNavigationItem asChild>
+      <SideNavigationItem asChild tooltipLabel="お問い合わせ">
         <a href="#" className="gap-xs flex items-center">
           <IconHelpCircle size={16} className="shrink-0" />
           {!isCollapsed && 'お問い合わせ'}
@@ -75,7 +84,7 @@ const Footer = () => {
       </SideNavigationItem>
       <Dropdown>
         <DropdownTrigger asChild>
-          <SideNavigationItem asChild>
+          <SideNavigationItem asChild tooltipLabel="各種設定">
             <button className="gap-xs flex items-center">
               <IconSettings size={16} className="shrink-0" />
               {!isCollapsed && '各種設定'}
@@ -114,25 +123,29 @@ export const Default: Story = {
       return (
         <>
           <SideNavigationSection title="SDS管理">
-            <SideNavigationItem asChild variant="selected">
+            <SideNavigationItem
+              asChild
+              variant="selected"
+              tooltipLabel="SDS登録"
+            >
               <a href="#" className="gap-xs flex items-center">
                 <IconUpload size={16} className="shrink-0" />
                 {!isCollapsed && 'SDS登録'}
               </a>
             </SideNavigationItem>
-            <SideNavigationItem asChild>
+            <SideNavigationItem asChild tooltipLabel="全SDS一覧">
               <a href="#" className="gap-xs flex items-center">
                 <IconTable size={16} className="shrink-0" />
                 {!isCollapsed && '全SDS一覧'}
               </a>
             </SideNavigationItem>
-            <SideNavigationItem asChild>
+            <SideNavigationItem asChild tooltipLabel="要確認SDS">
               <a href="#" className="gap-xs flex items-center">
                 <IconFileAlert size={16} className="shrink-0" />
                 {!isCollapsed && '要確認SDS'}
               </a>
             </SideNavigationItem>
-            <SideNavigationItem asChild>
+            <SideNavigationItem asChild tooltipLabel="削除済みSDS">
               <a href="#" className="gap-xs flex items-center">
                 <IconTrashX size={16} className="shrink-0" />
                 {!isCollapsed && '削除済みSDS'}
@@ -141,7 +154,7 @@ export const Default: Story = {
           </SideNavigationSection>
 
           <SideNavigationSection title="チェックリスト" isLast>
-            <SideNavigationItem asChild>
+            <SideNavigationItem asChild tooltipLabel="法令チェックリスト">
               <a href="#" className="gap-xs flex items-center">
                 <IconChecklist size={16} className="shrink-0" />
                 {!isCollapsed && '法令チェックリスト'}
@@ -207,7 +220,11 @@ export const WithCustomLinks: Story = {
       return (
         <>
           <SideNavigationSection title="Navigation with Custom Links">
-            <SideNavigationItem asChild variant="selected">
+            <SideNavigationItem
+              asChild
+              variant="selected"
+              tooltipLabel="SDS Registration"
+            >
               <MockNavigationLink
                 to="/sds-upload"
                 className="gap-xs flex items-center"
@@ -216,7 +233,7 @@ export const WithCustomLinks: Story = {
                 {!isCollapsed && 'SDS Registration'}
               </MockNavigationLink>
             </SideNavigationItem>
-            <SideNavigationItem asChild>
+            <SideNavigationItem asChild tooltipLabel="All SDS List">
               <MockNavigationLink
                 to="/sds-list"
                 className="gap-xs flex items-center"
@@ -225,7 +242,7 @@ export const WithCustomLinks: Story = {
                 {!isCollapsed && 'All SDS List'}
               </MockNavigationLink>
             </SideNavigationItem>
-            <SideNavigationItem asChild>
+            <SideNavigationItem asChild tooltipLabel="Alerts">
               <MockNavigationLink
                 to="/sds-alerts"
                 className="gap-xs flex items-center"
@@ -239,7 +256,7 @@ export const WithCustomLinks: Story = {
           </SideNavigationSection>
 
           <SideNavigationSection title="ReactNode Labels" isLast>
-            <SideNavigationItem asChild>
+            <SideNavigationItem asChild tooltipLabel="Checklist">
               <a href="#" className="gap-xs flex items-center">
                 <IconChecklist size={16} className="shrink-0" />
                 {!isCollapsed && (

--- a/src/components/SideNavigation/SideNavigation.tsx
+++ b/src/components/SideNavigation/SideNavigation.tsx
@@ -33,6 +33,8 @@ export interface SideNavigationProps
   header?: React.ReactNode;
   footer?: React.ReactNode;
   showCollapseButton?: boolean;
+  collapseLabel?: React.ReactNode;
+  expandLabel?: React.ReactNode;
   defaultCollapsed?: boolean;
 }
 
@@ -62,6 +64,8 @@ const SideNavigationContent = React.forwardRef<
       footer,
       children,
       showCollapseButton = false,
+      collapseLabel,
+      expandLabel,
       ...props
     },
     ref
@@ -119,7 +123,12 @@ const SideNavigationContent = React.forwardRef<
           </div>
         )}
 
-        {showCollapseButton && <SideNavigationCollapseButton />}
+        {showCollapseButton && (
+          <SideNavigationCollapseButton
+            collapseLabel={collapseLabel}
+            expandLabel={expandLabel}
+          />
+        )}
       </nav>
     );
   }

--- a/src/components/SideNavigation/SideNavigationCollapseButton.tsx
+++ b/src/components/SideNavigation/SideNavigationCollapseButton.tsx
@@ -1,20 +1,28 @@
 import React from 'react';
-import { IconChevronLeftPipe, IconChevronRightPipe } from '@tabler/icons-react';
+import {
+  IconLayoutSidebarLeftCollapse,
+  IconLayoutSidebarLeftExpand,
+} from '@tabler/icons-react';
 
 import { cn } from '../../lib/utils';
+import { Tooltip } from '../Tooltip';
 
 import { useSideNavigation } from './SideNavigationContext';
 
-export type SideNavigationCollapseButtonProps =
-  React.ButtonHTMLAttributes<HTMLButtonElement>;
+export interface SideNavigationCollapseButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  collapseLabel?: React.ReactNode;
+  expandLabel?: React.ReactNode;
+}
 
 export const SideNavigationCollapseButton = React.forwardRef<
   HTMLButtonElement,
   SideNavigationCollapseButtonProps
->(({ className, ...props }, ref) => {
+>(({ className, collapseLabel, expandLabel, ...props }, ref) => {
   const { isCollapsed, toggleCollapsed } = useSideNavigation();
+  const tooltipContent = isCollapsed ? expandLabel : collapseLabel;
 
-  return (
+  const button = (
     <button
       ref={ref}
       className={cn(
@@ -30,12 +38,22 @@ export const SideNavigationCollapseButton = React.forwardRef<
       {...props}
     >
       {isCollapsed ? (
-        <IconChevronRightPipe className="size-5" strokeWidth={2} />
+        <IconLayoutSidebarLeftExpand className="size-5" strokeWidth={2} />
       ) : (
-        <IconChevronLeftPipe className="size-5" strokeWidth={2} />
+        <IconLayoutSidebarLeftCollapse className="size-5" strokeWidth={2} />
       )}
     </button>
   );
+
+  if (tooltipContent) {
+    return (
+      <Tooltip content={tooltipContent} side="right" delayDuration={0}>
+        {button}
+      </Tooltip>
+    );
+  }
+
+  return button;
 });
 
 SideNavigationCollapseButton.displayName = 'SideNavigationCollapseButton';

--- a/src/components/SideNavigation/SideNavigationItem.tsx
+++ b/src/components/SideNavigation/SideNavigationItem.tsx
@@ -4,6 +4,7 @@ import { cva } from 'class-variance-authority';
 import { Slot } from 'radix-ui';
 
 import { cn } from '../../lib/utils';
+import { Tooltip } from '../Tooltip';
 
 import { useSideNavigation } from './SideNavigationContext';
 
@@ -43,6 +44,7 @@ export interface SideNavigationItemProps
   asChild?: boolean;
   component?: React.ElementType;
   label?: React.ReactNode;
+  tooltipLabel?: React.ReactNode;
 }
 
 export const SideNavigationItem = React.forwardRef<
@@ -56,6 +58,7 @@ export const SideNavigationItem = React.forwardRef<
       size,
       asChild = false,
       label,
+      tooltipLabel,
       children,
       disabled,
       ...props
@@ -66,7 +69,7 @@ export const SideNavigationItem = React.forwardRef<
     const Comp = asChild ? Slot.Root : 'button';
     const finalVariant = disabled ? 'disabled' : variant;
 
-    return (
+    const item = (
       <Comp
         ref={ref}
         className={cn(
@@ -84,6 +87,16 @@ export const SideNavigationItem = React.forwardRef<
         {children || label}
       </Comp>
     );
+
+    if (isCollapsed && tooltipLabel) {
+      return (
+        <Tooltip content={tooltipLabel} side="right" delayDuration={0}>
+          {item}
+        </Tooltip>
+      );
+    }
+
+    return item;
   }
 );
 


### PR DESCRIPTION
## Issue information
When the side navigation is collapsed, only icons are visible with no indication of the link name.

<img width="428" height="312" alt="image" src="https://github.com/user-attachments/assets/71919910-3ed6-4177-a00d-8a7d3d088c67" />


## Overview
- Add a `tooltipLabel` prop to `SideNavigationItem`
- When collapsed and `tooltipLabel` is provided, the item is wrapped in a `Tooltip` (side="right") showing the link name on hover
- Assumes a `TooltipProvider` is set up in the consuming application's component tree

## Dependencies
- Requires `TooltipProvider` from `@radix-ui/react-tooltip` to be present in the ancestor tree

## Steps to Test
- Open Storybook and navigate to Components/SideNavigation
- Collapse the navigation using the collapse button
- Hover over any nav item and verify a tooltip appears to the right with the link name
- Expand the navigation and verify no tooltips appear