### PR TITLE
feat(Callout): Support href in action prop

### DIFF
--- a/src/components/Callout/Callout.stories.tsx
+++ b/src/components/Callout/Callout.stories.tsx
@@ -129,6 +129,22 @@ WithDescriptionAndAction.args = {
   intent: 'info',
 };
 
+export const WithLinkAction: StoryFn<typeof Callout> = (args) => (
+  <Callout {...args} />
+);
+
+WithLinkAction.args = {
+  title: 'ヘルプセンター',
+  description: '詳しくはヘルプセンターをご確認ください。',
+  action: {
+    label: 'ヘルプを見る',
+    href: 'https://example.com/help',
+    target: '_blank',
+    rel: 'noopener noreferrer',
+  },
+  intent: 'info',
+};
+
 export const Success: StoryFn<typeof Callout> = (args) => <Callout {...args} />;
 
 Success.args = {

--- a/src/components/Callout/Callout.tsx
+++ b/src/components/Callout/Callout.tsx
@@ -83,6 +83,9 @@ export interface CalloutProps
   action?: {
     label: React.ReactNode;
     onClick?: () => void;
+    href?: string;
+    target?: React.HTMLAttributeAnchorTarget;
+    rel?: string;
   };
   icon?: IconProp;
 }
@@ -120,18 +123,29 @@ export const Callout = React.forwardRef<HTMLDivElement, CalloutProps>(
                 </div>
                 <div className={cn(titleVariants({ intent }))}>{title}</div>
               </div>
-              {action && (
-                <TextLink
-                  onClick={action.onClick}
-                  intent="primary"
-                  size="sm"
-                  asChild
-                >
-                  <button type="button" className="cursor-pointer">
+              {action &&
+                (action.href ? (
+                  <TextLink
+                    href={action.href}
+                    target={action.target}
+                    rel={action.rel}
+                    intent="primary"
+                    size="sm"
+                  >
                     {action.label}
-                  </button>
-                </TextLink>
-              )}
+                  </TextLink>
+                ) : (
+                  <TextLink
+                    onClick={action.onClick}
+                    intent="primary"
+                    size="sm"
+                    asChild
+                  >
+                    <button type="button" className="cursor-pointer">
+                      {action.label}
+                    </button>
+                  </TextLink>
+                ))}
             </div>
           )}
           {(children || description) && (


### PR DESCRIPTION
## Issue information

N/A

## Overview

Extends the Callout component's `action` prop to support `href`, `target`, and `rel` properties, allowing the action to render as a link (`<a>`) instead of only a `<button>`.

## Dependencies

- Callout component
- TextLink component

## Steps to Test

- Open Storybook and navigate to the Callout stories
- Verify the new `WithLinkAction` story renders the action as a link
- Verify existing `WithAction` and `WithDescriptionAndAction` stories still work with `onClick`