### PR TITLE
feat: Guard Enter handlers during IME composition

### DIFF
--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -4,6 +4,7 @@ import { cva } from 'class-variance-authority';
 import { IconSearch, IconX } from '@tabler/icons-react';
 
 import { cn } from '../../lib/utils';
+import { useCompositionGuard } from '../../lib/hooks';
 
 const searchBarWrapperVariants = cva(
   `rounded-sm bg-surface-primary border-interactive-default
@@ -146,6 +147,9 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
     }
     const prevResolvedState = React.useRef(resolvedState);
 
+    const { compositionHandlers, guardKeyHandler } =
+      useCompositionGuard<HTMLInputElement>();
+
     useEffect(() => {
       // If transitioning from 'filled' to another state, clear keywords
       if (
@@ -267,7 +271,9 @@ export const SearchBar = React.forwardRef<HTMLInputElement, SearchBarProps>(
                 type="text"
                 value={value}
                 onChange={handleInputChange}
-                onKeyDown={handleKeyDown}
+                onKeyDown={guardKeyHandler(handleKeyDown)}
+                onCompositionStart={compositionHandlers.onCompositionStart}
+                onCompositionEnd={compositionHandlers.onCompositionEnd}
                 onFocus={(e) => {
                   setInputFocused(true);
                   props.onFocus?.(e);

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -3,6 +3,7 @@ import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 
 import { cn } from '../../utils';
+import { useCompositionGuard } from '../../lib/hooks';
 
 const textareaVariants = cva(
   `border-interactive-default bg-surface-primary px-md py-sm text-body-primary
@@ -40,11 +41,36 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
     },
     ref
   ) => {
+    const {
+      onKeyDown,
+      onKeyUp,
+      onCompositionStart,
+      onCompositionEnd,
+      onChange,
+      value: _value,
+      ...textareaProps
+    } = props;
+
     const [text, setText] = useState(props.value);
 
     useEffect(() => {
       setText(props.value);
     }, [props.value]);
+
+    const { compositionHandlers, guardKeyHandler } =
+      useCompositionGuard<HTMLTextAreaElement>();
+    const handleCompositionStart: React.CompositionEventHandler<
+      HTMLTextAreaElement
+    > = (event) => {
+      compositionHandlers.onCompositionStart(event);
+      onCompositionStart?.(event);
+    };
+    const handleCompositionEnd: React.CompositionEventHandler<
+      HTMLTextAreaElement
+    > = (event) => {
+      compositionHandlers.onCompositionEnd(event);
+      onCompositionEnd?.(event);
+    };
 
     const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
       if (characterLimit && event.target.value.length > characterLimit) {
@@ -53,8 +79,8 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
       }
 
       setText(event.target.value);
-      if (props.onChange) {
-        props.onChange(event);
+      if (onChange) {
+        onChange(event);
       }
     };
 
@@ -63,9 +89,13 @@ export const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
         <textarea
           ref={ref}
           className={cn(textareaVariants({ invalid }), className)}
-          {...props}
+          {...textareaProps}
           value={text}
           onChange={handleChange}
+          onKeyDown={guardKeyHandler(onKeyDown)}
+          onKeyUp={guardKeyHandler(onKeyUp)}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
         />
         {Boolean(characterLimit && showCharacterLimit) && (
           <div className="text-body-secondary text-sm text-right">

--- a/src/components/TextField/AutoSuggest.tsx
+++ b/src/components/TextField/AutoSuggest.tsx
@@ -106,7 +106,6 @@ export const AutoSuggest = React.forwardRef<HTMLInputElement, AutoSuggestProps>(
     const abortControllerRef = useRef<AbortController | null>(null);
     const [highlightedIndex, setHighlightedIndex] = useState<number>(0);
     const itemRefs = useRef<(HTMLDivElement | null)[]>([]);
-    const [isComposing, setIsComposing] = useState(false);
     const debouncedQuery = useDebounce(value, debounceMs);
 
     const filteredSuggestions = useMemo(() => {
@@ -225,10 +224,6 @@ export const AutoSuggest = React.forwardRef<HTMLInputElement, AutoSuggestProps>(
 
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (isComposing) {
-          return;
-        }
-
         if (!open) {
           onKeyDownProp?.(e);
           return;
@@ -264,14 +259,7 @@ export const AutoSuggest = React.forwardRef<HTMLInputElement, AutoSuggestProps>(
 
         onKeyDownProp?.(e);
       },
-      [
-        isComposing,
-        open,
-        highlightedIndex,
-        filteredSuggestions,
-        handleSelect,
-        onKeyDownProp,
-      ]
+      [open, highlightedIndex, filteredSuggestions, handleSelect, onKeyDownProp]
     );
 
     const shouldShowPopover =
@@ -292,8 +280,6 @@ export const AutoSuggest = React.forwardRef<HTMLInputElement, AutoSuggestProps>(
             onFocus={handleFocus}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
-            onCompositionStart={() => setIsComposing(true)}
-            onCompositionEnd={() => setIsComposing(false)}
             disabled={disabled}
             role="combobox"
             aria-expanded={shouldShowPopover}

--- a/src/components/TextField/TagInput.tsx
+++ b/src/components/TextField/TagInput.tsx
@@ -8,6 +8,7 @@ import React, {
 
 import type { IconProp } from '../../lib/utils';
 import { cn, renderIcon } from '../../lib/utils';
+import { useCompositionGuard } from '../../lib/hooks';
 import { Tag } from '../Tag/Tag';
 
 import { inputWrapperVariants, iconVariants } from './TextField';
@@ -67,8 +68,8 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
     // Track focus state for helper text
     const [isFocused, setIsFocused] = useState(false);
 
-    // Track IME composition state
-    const [isComposing, setIsComposing] = useState(false);
+    const { compositionHandlers, guardKeyHandler } =
+      useCompositionGuard<HTMLInputElement>();
 
     // Track validation error
     const [validationError, setValidationError] =
@@ -170,8 +171,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
     // Handle key down - Enter and Backspace
     const handleKeyDown = useCallback(
       (e: KeyboardEvent<HTMLInputElement>) => {
-        // Don't process Enter key during IME composition
-        if (e.key === 'Enter' && inputValue.trim() && !isComposing) {
+        if (e.key === 'Enter' && inputValue.trim()) {
           e.preventDefault();
           addTag(inputValue);
         }
@@ -185,7 +185,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
           removeTag(tags.length - 1);
         }
       },
-      [inputValue, tags.length, addTag, removeTag, isComposing]
+      [inputValue, tags.length, addTag, removeTag]
     );
 
     // Handle blur - add current value as tag if not empty
@@ -243,11 +243,11 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
               ref={inputRef}
               value={inputValue}
               onChange={handleInputChange}
-              onKeyDown={handleKeyDown}
+              onKeyDown={guardKeyHandler(handleKeyDown)}
               onFocus={() => setIsFocused(true)}
               onBlur={handleBlur}
-              onCompositionStart={() => setIsComposing(true)}
-              onCompositionEnd={() => setIsComposing(false)}
+              onCompositionStart={compositionHandlers.onCompositionStart}
+              onCompositionEnd={compositionHandlers.onCompositionEnd}
               placeholder={showPlaceholder ? placeholder : ''}
               disabled={isDisabled}
               className={cn(

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -85,3 +85,41 @@ Numeric.args = {
   defaultValue: '-0.5',
   step: '0.1',
 };
+
+/**
+ * IME composition guard demo.
+ *
+ * Switch your OS input source to Japanese (or any IME-based language) and
+ * type into the field. Press Enter to confirm an IME candidate — the submit
+ * counter must NOT increase. Press Enter again with no active composition,
+ * and the counter increments. With ASCII input, every Enter increments
+ * normally.
+ */
+export const ImeCompositionGuard: StoryFn<typeof TextField> = () => {
+  const [value, setValue] = React.useState('');
+  const [submits, setSubmits] = React.useState<string[]>([]);
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <TextField
+        placeholder="日本語で入力して Enter で確定 / type and press Enter"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            setSubmits((prev) => [...prev, value]);
+            setValue('');
+          }
+        }}
+      />
+      <div style={{ fontSize: 14 }}>
+        Submits ({submits.length}):
+        <ul>
+          {submits.map((s, i) => (
+            <li key={i}>{s || <em>(empty)</em>}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -4,6 +4,7 @@ import { cva } from 'class-variance-authority';
 
 import type { IconProp } from '../../lib/utils';
 import { cn, renderIcon } from '../../lib/utils';
+import { useCompositionGuard } from '../../lib/hooks';
 
 export const inputWrapperVariants = cva(
   `border-interactive-default bg-surface-primary
@@ -91,6 +92,10 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
       trailingIconSize = 14,
       prefixIconSize = 14,
       className,
+      onKeyDown,
+      onKeyUp,
+      onCompositionStart,
+      onCompositionEnd,
       ...props
     },
     ref
@@ -99,6 +104,21 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
     const hasTrailing = !!trailingIcon;
     const isTrailingInteractive = !!onTrailingIconClick;
     const isNumeric = props.type === 'number';
+
+    const { compositionHandlers, guardKeyHandler } =
+      useCompositionGuard<HTMLInputElement>();
+    const handleCompositionStart: React.CompositionEventHandler<
+      HTMLInputElement
+    > = (event) => {
+      compositionHandlers.onCompositionStart(event);
+      onCompositionStart?.(event);
+    };
+    const handleCompositionEnd: React.CompositionEventHandler<
+      HTMLInputElement
+    > = (event) => {
+      compositionHandlers.onCompositionEnd(event);
+      onCompositionEnd?.(event);
+    };
 
     return (
       <div className={cn(inputWrapperVariants({ invalid }), className)}>
@@ -113,6 +133,10 @@ export const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
           ref={ref}
           className={inputVariants({ hasPrefix, hasTrailing, isNumeric })}
           {...props}
+          onKeyDown={guardKeyHandler(onKeyDown)}
+          onKeyUp={guardKeyHandler(onKeyUp)}
+          onCompositionStart={handleCompositionStart}
+          onCompositionEnd={handleCompositionEnd}
         />
         {trailingIcon && (
           <>

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,1 +1,6 @@
 export { useDebounce } from './useDebounce';
+export { useCompositionGuard } from './useCompositionGuard';
+export type {
+  CompositionHandlers,
+  UseCompositionGuardResult,
+} from './useCompositionGuard';

--- a/src/lib/hooks/useCompositionGuard.ts
+++ b/src/lib/hooks/useCompositionGuard.ts
@@ -1,0 +1,80 @@
+import { useCallback, useRef } from 'react';
+import type { CompositionEventHandler, KeyboardEvent } from 'react';
+
+export interface CompositionHandlers<T extends Element> {
+  onCompositionStart: CompositionEventHandler<T>;
+  onCompositionEnd: CompositionEventHandler<T>;
+}
+
+export interface UseCompositionGuardResult<T extends Element> {
+  /**
+   * Spread these handlers onto the input/textarea so the hook can track IME
+   * composition state.
+   */
+  compositionHandlers: CompositionHandlers<T>;
+  /**
+   * Wraps a keyboard handler so it is skipped while an IME composition is in
+   * progress. Use this for any onKeyDown / onKeyUp handler that has Enter (or
+   * other confirm-style) semantics, to avoid triggering submission when the
+   * user is just confirming an IME candidate.
+   */
+  guardKeyHandler: <E extends KeyboardEvent<T>>(
+    handler: ((event: E) => void) | undefined
+  ) => ((event: E) => void) | undefined;
+  /**
+   * Imperative check (current value of `isComposing`). Prefer `guardKeyHandler`
+   * for handler wrapping; use this only when integrating with code that cannot
+   * use the wrapper.
+   */
+  isComposingRef: React.RefObject<boolean>;
+}
+
+/**
+ * Tracks IME composition state so that Enter (and similar) key events fired
+ * while the user is confirming a Japanese / Chinese / Korean IME candidate are
+ * not interpreted as form submission.
+ *
+ * Browsers fire `compositionend` before `keydown` for the confirming Enter on
+ * modern engines, but Safari historically fires `keydown` first; therefore the
+ * wrapper additionally checks `event.nativeEvent.isComposing` (and the legacy
+ * `keyCode === 229`) to cover both orderings.
+ */
+export const useCompositionGuard = <
+  T extends Element = HTMLInputElement,
+>(): UseCompositionGuardResult<T> => {
+  const isComposingRef = useRef(false);
+
+  const onCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const onCompositionEnd = useCallback(() => {
+    isComposingRef.current = false;
+  }, []);
+
+  const guardKeyHandler = useCallback(
+    <E extends KeyboardEvent<T>>(handler: ((event: E) => void) | undefined) => {
+      if (!handler) return undefined;
+      return (event: E) => {
+        const native = event.nativeEvent as KeyboardEvent['nativeEvent'] & {
+          isComposing?: boolean;
+        };
+        if (
+          isComposingRef.current ||
+          native.isComposing === true ||
+          event.keyCode === 229
+        ) {
+          return;
+        }
+        handler(event);
+      };
+    },
+    []
+  );
+
+  return {
+    compositionHandlers: { onCompositionStart, onCompositionEnd },
+    guardKeyHandler,
+    isComposingRef,
+  };
+};


### PR DESCRIPTION
## Overview

Make IME (Japanese / Chinese / Korean) composition handling a library-default concern instead of leaving it to consumers. Previously, pressing Enter to confirm an IME candidate could be interpreted as form submission, list selection, or chip creation in components that handled Enter on text inputs.

## Changes

- **New hook** `useCompositionGuard` (`src/lib/hooks/useCompositionGuard.ts`): exposes composition handlers and a `guardKeyHandler` wrapper that skips key events fired during IME composition. Triple-checks via internal ref, `event.nativeEvent.isComposing`, and legacy `keyCode === 229` so both modern Chromium/Firefox and Safari event orderings are covered.
- **TextField**: consumer-supplied `onKeyDown` / `onKeyUp` are now wrapped automatically. Any bare `<TextField onKeyDown={submit} />` is correct by default. Consumer `onCompositionStart` / `onCompositionEnd` still fire after the internal trackers.
- **TextArea**: same treatment.
- **SearchBar**: guards its internal keyword-add Enter handler.
- **TagInput**: migrated from local `isComposing` state to the shared hook (behavior unchanged, less code).
- **AutoSuggest**: local composition tracking removed - relies on the now auto-guarded `TextField` underneath.
- **DatePicker**: covered transitively via `TextField`; no change required.
- **Storybook**: added `TextField` story `ImeCompositionGuard` for manual verification.

## Compatibility

For non-IME (ASCII) input, behavior is unchanged - `compositionstart` / `compositionend` simply do not fire, so the guard never trips. No public API changes; no breaking changes for consumers.

## Steps to Test

- `npm run storybook`
- Open `Components/TextField -> Ime Composition Guard`. Switch OS input to Japanese, type some kana, press Enter to confirm the candidate -> the submits list must NOT grow. Press Enter again (no active composition) -> the confirmed text submits and counter increments. With ASCII input, every Enter increments.
- Repeat the same Enter-during-IME check on the existing `SearchBar`, `TagInput`, and `AutoSuggest` stories - none should fire their action while confirming an IME candidate.
- `npm run typecheck` and `npm run lint` are clean.