### PR TITLE
feat(Dialog): Add bodyClassName prop

### DIFF
--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -1,6 +1,7 @@
 import React, { type ReactNode } from 'react';
 import { Dialog as RadixDialog } from 'radix-ui';
 
+import { cn } from '../../lib/utils';
 import { Button } from '../Button';
 import type { ButtonProps } from '../Button';
 
@@ -29,6 +30,7 @@ export interface DialogProps
   onOpenAutoFocus?: React.ComponentProps<
     typeof RadixDialog.Content
   >['onOpenAutoFocus'];
+  bodyClassName?: string;
 }
 
 const defaultActions: DialogAction[] = [
@@ -51,6 +53,7 @@ export const Dialog: React.FC<DialogProps> = ({
   cancelButtonLabel = 'キャンセル',
   allowClickOutside = true,
   onOpenAutoFocus,
+  bodyClassName,
 }) => {
   const [loading, setLoading] = React.useState<number>(-1);
 
@@ -127,9 +130,12 @@ export const Dialog: React.FC<DialogProps> = ({
             </header>
 
             <div
-              className="border-divider-default bg-surface-secondary px-xl pt-md
-                pb-xxl text-body-primary max-h-[70vh] flex-1 overflow-hidden
-                overflow-y-auto border-y-1"
+              className={cn(
+                `border-divider-default bg-surface-secondary px-xl pt-md pb-xxl
+                text-body-primary max-h-[70vh] flex-1 overflow-hidden
+                overflow-y-auto border-y-1`,
+                bodyClassName
+              )}
             >
               {children}
             </div>


### PR DESCRIPTION
## Issue information

N/A

## Overview

Adds a `bodyClassName` prop to the `Dialog` component, allowing consumers to pass additional class names to the body section (the `<div>` wrapping `children`). Classes are merged using the existing `cn` utility (tailwind-merge) so consumers can safely override default styles.

## Dependencies

- Dialog component

## Steps to Test

- Render a `Dialog` with `bodyClassName` set (e.g. `bodyClassName="max-h-none"`)
- Verify the custom class is applied to the body section and merges correctly with defaults