### PR TITLE
Remove deprecated keyCode === 229 check

### DIFF
--- a/src/lib/hooks/useCompositionGuard.ts
+++ b/src/lib/hooks/useCompositionGuard.ts
@@ -36,8 +36,8 @@ export interface UseCompositionGuardResult<T extends Element> {
  *
  * Browsers fire `compositionend` before `keydown` for the confirming Enter on
  * modern engines, but Safari historically fires `keydown` first; therefore the
- * wrapper additionally checks `event.nativeEvent.isComposing` (and the legacy
- * `keyCode === 229`) to cover both orderings.
+ * wrapper additionally checks `event.nativeEvent.isComposing` to cover both
+ * orderings.
  */
 export const useCompositionGuard = <
   T extends Element = HTMLInputElement,
@@ -59,11 +59,7 @@ export const useCompositionGuard = <
         const native = event.nativeEvent as KeyboardEvent['nativeEvent'] & {
           isComposing?: boolean;
         };
-        if (
-          isComposingRef.current ||
-          native.isComposing === true ||
-          event.keyCode === 229
-        ) {
+        if (isComposingRef.current || native.isComposing === true) {
           return;
         }
         handler(event);


### PR DESCRIPTION
## Issue information

Follow-up from PR #125 review comment.

## Overview

Removes the deprecated `event.keyCode === 229` check from `useCompositionGuard`. The check is redundant since `isComposingRef` and `nativeEvent.isComposing` already cover IME composition detection.

## Dependencies

None

## Steps to Test

- Verify IME composition guard still works correctly in TextField, TextArea, and SearchBar with a CJK input method