### PR TITLE
fix(Tag): Prevent truncation from clipping text descenders

### DIFF
--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -245,8 +245,8 @@ export interface TagProps {
 }
 
 const tagVariants = cva(
-  `gap-xxs py-xxs px-xs h-5.5 inline-flex max-w-full items-center rounded-full
-  border border-transparent leading-none`,
+  `gap-xxs px-xs h-5.5 inline-flex max-w-full items-center rounded-full border
+  border-transparent leading-none`,
   {
     variants: {
       size: {
@@ -354,7 +354,7 @@ export const Tag: React.FC<TagProps> = ({
           {renderIcon(icon, { size: 14 })}
         </span>
       )}
-      <div className="truncate">{children}</div>
+      <div className="pt-0.5 relative h-full truncate">{children}</div>
       {Boolean(onRemove) && !disabled && (
         <button
           className={cn(


### PR DESCRIPTION
## Issue information

Text descenders (g, y, p, q, etc.) were being clipped inside Tag components due to `overflow: hidden` from the `truncate` utility.

<img width="106" height="64" alt="image" src="https://github.com/user-attachments/assets/ba6ea3d2-d595-4eae-b227-668fda09a179" />

## Overview

- Removed vertical padding (`py-xxs`) from the tag container
- Added `pt-0.5` to the text div to shift content enough to preserve descenders within the truncated area

## Steps to Test

- Render a Tag with text containing descenders (e.g. "Typography")
- Verify descenders are fully visible
- Verify long text still truncates with ellipsis