### PR TITLE
feat(DataSheet): Add trailingContent prop to KeyValue component

### DIFF
--- a/src/components/DataSheet/DataSheet.stories.tsx
+++ b/src/components/DataSheet/DataSheet.stories.tsx
@@ -671,12 +671,7 @@ export const KeyValueWithTrailingContent: Story = () => (
         }
       >
         <span>第32次SVHCリストへの対応。抽出条件の最適化を実施しました。</span>
-        <Button
-          size="xs"
-          intent="secondary"
-          trailingIcon={IconExternalLink}
-          className="w-full"
-        >
+        <Button size="xs" intent="secondary" trailingIcon={IconExternalLink}>
           法令データベースで詳細を確認
         </Button>
       </DataSheet.KeyValue>
@@ -703,7 +698,7 @@ export const KeyValueWithTrailingContent: Story = () => (
           trailingIcon={IconExternalLink}
           className="w-full"
         >
-          法令データベースで詳細を確認
+          法令データベースで詳細を確認（フル幅）
         </Button>
       </DataSheet.KeyValue>
     </DataSheet.Section>

--- a/src/components/DataSheet/DataSheet.stories.tsx
+++ b/src/components/DataSheet/DataSheet.stories.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import type { Meta, StoryFn } from 'storybook/react-vite';
-import { IconPlus } from '@tabler/icons-react';
+import { IconExternalLink, IconPlus } from '@tabler/icons-react';
 
 import { Accordion } from '../Accordion';
+import { Button } from '../Button/Button';
 import { DatePicker } from '../DatePicker/DatePicker';
 import { TextArea } from '../TextArea/TextArea';
 import { TextField } from '../TextField/TextField';
@@ -645,6 +646,75 @@ KeyValueWithFormFields.parameters = {
         '`aria-labelledby`, so screen readers announce the label and ' +
         '`findByLabelText` queries resolve correctly. Inspect any input — ' +
         'its `aria-labelledby` points at the sibling label `<div>`.',
+    },
+  },
+};
+
+export const KeyValueWithTrailingContent: Story = () => (
+  <DataSheet className="w-200">
+    <DataSheet.Header>抽出条件更新履歴</DataSheet.Header>
+    <DataSheet.Section>
+      <DataSheet.KeyValue
+        label={
+          <span className="text-md font-bold text-body-primary">
+            v2025-02-18
+          </span>
+        }
+        trailingContent={
+          <div className="gap-xxs flex flex-col items-end">
+            <span>更新日 2025年02月18日</span>
+            <span>更新者 ユーザー クライアント</span>
+          </div>
+        }
+      >
+        <div className="gap-xs flex flex-col">
+          <span>
+            第32次SVHCリストへの対応。抽出条件の最適化を実施しました。
+          </span>
+          <Button
+            size="xs"
+            intent="secondary"
+            icon={IconExternalLink}
+            iconPosition="trailing"
+          >
+            法令データベースで詳細を確認
+          </Button>
+        </div>
+      </DataSheet.KeyValue>
+      <DataSheet.KeyValue
+        label={
+          <span className="text-md font-bold text-body-primary">
+            v2025-02-01
+          </span>
+        }
+        trailingContent={
+          <div className="gap-xxs flex flex-col items-end">
+            <span>更新日 2025年02月01日</span>
+            <span>更新者 ユーザー クライアント</span>
+          </div>
+        }
+      >
+        <div className="gap-xs flex flex-col">
+          <span>POPs条約附属書の改正に対応しました。</span>
+          <Button
+            size="xs"
+            intent="secondary"
+            icon={IconExternalLink}
+            iconPosition="trailing"
+          >
+            法令データベースで詳細を確認
+          </Button>
+        </div>
+      </DataSheet.KeyValue>
+    </DataSheet.Section>
+  </DataSheet>
+);
+KeyValueWithTrailingContent.parameters = {
+  docs: {
+    description: {
+      story:
+        'Use `trailingContent` prop to display right-aligned secondary information ' +
+        'like dates, user info, or metadata alongside the main content.',
     },
   },
 };

--- a/src/components/DataSheet/DataSheet.stories.tsx
+++ b/src/components/DataSheet/DataSheet.stories.tsx
@@ -661,25 +661,24 @@ export const KeyValueWithTrailingContent: Story = () => (
           </span>
         }
         trailingContent={
-          <div className="gap-xxs flex flex-col items-end">
+          <div
+            className="text-body-secondary gap-xxs text-sm flex flex-col
+              items-end text-right"
+          >
             <span>更新日 2025年02月18日</span>
             <span>更新者 ユーザー クライアント</span>
           </div>
         }
       >
-        <div className="gap-xs flex flex-col">
-          <span>
-            第32次SVHCリストへの対応。抽出条件の最適化を実施しました。
-          </span>
-          <Button
-            size="xs"
-            intent="secondary"
-            icon={IconExternalLink}
-            iconPosition="trailing"
-          >
-            法令データベースで詳細を確認
-          </Button>
-        </div>
+        <span>第32次SVHCリストへの対応。抽出条件の最適化を実施しました。</span>
+        <Button
+          size="xs"
+          intent="secondary"
+          trailingIcon={IconExternalLink}
+          className="w-full"
+        >
+          法令データベースで詳細を確認
+        </Button>
       </DataSheet.KeyValue>
       <DataSheet.KeyValue
         label={
@@ -688,23 +687,24 @@ export const KeyValueWithTrailingContent: Story = () => (
           </span>
         }
         trailingContent={
-          <div className="gap-xxs flex flex-col items-end">
+          <div
+            className="text-body-secondary gap-xxs text-sm flex flex-col
+              items-end text-right"
+          >
             <span>更新日 2025年02月01日</span>
             <span>更新者 ユーザー クライアント</span>
           </div>
         }
       >
-        <div className="gap-xs flex flex-col">
-          <span>POPs条約附属書の改正に対応しました。</span>
-          <Button
-            size="xs"
-            intent="secondary"
-            icon={IconExternalLink}
-            iconPosition="trailing"
-          >
-            法令データベースで詳細を確認
-          </Button>
-        </div>
+        <span>POPs条約附属書の改正に対応しました。</span>
+        <Button
+          size="xs"
+          intent="secondary"
+          trailingIcon={IconExternalLink}
+          className="w-full"
+        >
+          法令データベースで詳細を確認
+        </Button>
       </DataSheet.KeyValue>
     </DataSheet.Section>
   </DataSheet>

--- a/src/components/DataSheet/DataSheet.tsx
+++ b/src/components/DataSheet/DataSheet.tsx
@@ -235,47 +235,92 @@ export interface DataSheetKeyValueProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof dataSheetKeyValueVariants> {
   label: React.ReactNode;
+  /**
+   * Optional content to display on the right side of the row.
+   * Useful for secondary information like dates, user info, or metadata.
+   */
+  trailingContent?: React.ReactNode;
 }
 
 const DataSheetKeyValue = React.forwardRef<
   HTMLDivElement,
   DataSheetKeyValueProps
->(({ className, label, orientation, spacing, children, ...props }, ref) => {
-  const labelId = React.useId();
+>(
+  (
+    {
+      className,
+      label,
+      orientation,
+      spacing,
+      trailingContent,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const labelId = React.useId();
 
-  const labelledChildren = React.Children.map(children, (child) => {
-    if (!React.isValidElement(child)) return child;
-    const childProps = child.props as { 'aria-labelledby'?: string };
-    const existing = childProps['aria-labelledby'];
-    return React.cloneElement(
-      child as React.ReactElement<Record<string, unknown>>,
-      {
-        'aria-labelledby': existing ? `${existing} ${labelId}` : labelId,
-      }
+    const labelledChildren = React.Children.map(children, (child) => {
+      if (!React.isValidElement(child)) return child;
+      const childProps = child.props as { 'aria-labelledby'?: string };
+      const existing = childProps['aria-labelledby'];
+      return React.cloneElement(
+        child as React.ReactElement<Record<string, unknown>>,
+        {
+          'aria-labelledby': existing ? `${existing} ${labelId}` : labelId,
+        }
+      );
+    });
+
+    const mainContent = (
+      <>
+        <div
+          id={labelId}
+          className={cn(dataSheetKeyValueLabelVariants({ orientation }))}
+        >
+          {label}
+        </div>
+        <div className={cn(dataSheetKeyValueValueVariants({ orientation }))}>
+          {labelledChildren}
+        </div>
+      </>
     );
-  });
 
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        dataSheetKeyValueVariants({ orientation, spacing }),
-        className
-      )}
-      {...props}
-    >
+    return (
       <div
-        id={labelId}
-        className={cn(dataSheetKeyValueLabelVariants({ orientation }))}
+        ref={ref}
+        className={cn(
+          dataSheetKeyValueVariants({ orientation, spacing }),
+          trailingContent && 'flex-row! items-start justify-between',
+          className
+        )}
+        {...props}
       >
-        {label}
+        {trailingContent ? (
+          <>
+            <div
+              className={cn(
+                orientation === 'horizontal'
+                  ? 'flex items-center'
+                  : 'gap-xxs flex flex-col',
+                'min-w-0 flex-1'
+              )}
+            >
+              {mainContent}
+            </div>
+            <div
+              className="text-body-secondary ml-md text-sm shrink-0 text-right"
+            >
+              {trailingContent}
+            </div>
+          </>
+        ) : (
+          mainContent
+        )}
       </div>
-      <div className={cn(dataSheetKeyValueValueVariants({ orientation }))}>
-        {labelledChildren}
-      </div>
-    </div>
-  );
-});
+    );
+  }
+);
 DataSheetKeyValue.displayName = 'DataSheetKeyValue';
 
 export type DataSheetItemType = string | number | object;

--- a/src/components/DataSheet/DataSheet.tsx
+++ b/src/components/DataSheet/DataSheet.tsx
@@ -286,25 +286,33 @@ const DataSheetKeyValue = React.forwardRef<
       </>
     );
 
-    if (trailingContent) {
-      return (
-        <section
-          ref={ref}
-          className={cn('gap-xs py-sm flex flex-col', className)}
-          {...props}
+    const withTrailingContent = (
+      <section
+        ref={ref}
+        className={cn('gap-xs py-sm flex flex-col', className)}
+        {...props}
+      >
+        <div className="gap-md flex items-start justify-between">
+          <div
+            id={labelId}
+            className={cn(dataSheetKeyValueLabelVariants({ orientation }))}
+          >
+            {label}
+          </div>
+          <div>{trailingContent}</div>
+        </div>
+        <div
+          className={cn(
+            dataSheetKeyValueValueVariants({ orientation }),
+            'gap-xs flex flex-col items-start'
+          )}
         >
-          <div className="gap-md flex items-start justify-between">
-            <div id={labelId}>{label}</div>
-            <div>{trailingContent}</div>
-          </div>
-          <div className={cn(dataSheetKeyValueValueVariants({ orientation }))}>
-            {labelledChildren}
-          </div>
-        </section>
-      );
-    }
+          {labelledChildren}
+        </div>
+      </section>
+    );
 
-    return (
+    const withoutTrailingContent = (
       <div
         ref={ref}
         className={cn(
@@ -316,6 +324,8 @@ const DataSheetKeyValue = React.forwardRef<
         {mainContent}
       </div>
     );
+
+    return trailingContent ? withTrailingContent : withoutTrailingContent;
   }
 );
 DataSheetKeyValue.displayName = 'DataSheetKeyValue';

--- a/src/components/DataSheet/DataSheet.tsx
+++ b/src/components/DataSheet/DataSheet.tsx
@@ -286,37 +286,34 @@ const DataSheetKeyValue = React.forwardRef<
       </>
     );
 
+    if (trailingContent) {
+      return (
+        <section
+          ref={ref}
+          className={cn('gap-xs py-sm flex flex-col', className)}
+          {...props}
+        >
+          <div className="gap-md flex items-start justify-between">
+            <div id={labelId}>{label}</div>
+            <div>{trailingContent}</div>
+          </div>
+          <div className={cn(dataSheetKeyValueValueVariants({ orientation }))}>
+            {labelledChildren}
+          </div>
+        </section>
+      );
+    }
+
     return (
       <div
         ref={ref}
         className={cn(
           dataSheetKeyValueVariants({ orientation, spacing }),
-          trailingContent && 'flex-row! items-start justify-between',
           className
         )}
         {...props}
       >
-        {trailingContent ? (
-          <>
-            <div
-              className={cn(
-                orientation === 'horizontal'
-                  ? 'flex items-center'
-                  : 'gap-xxs flex flex-col',
-                'min-w-0 flex-1'
-              )}
-            >
-              {mainContent}
-            </div>
-            <div
-              className="text-body-secondary ml-md text-sm shrink-0 text-right"
-            >
-              {trailingContent}
-            </div>
-          </>
-        ) : (
-          mainContent
-        )}
+        {mainContent}
       </div>
     );
   }

--- a/src/components/SideNavigation/SideNavigation.stories.tsx
+++ b/src/components/SideNavigation/SideNavigation.stories.tsx
@@ -21,7 +21,6 @@ import {
   DropdownItem,
   DropdownSeparator,
 } from '../DropdownMenu';
-
 import { TooltipProvider } from '../Tooltip';
 
 import { SideNavigation } from './SideNavigation';


### PR DESCRIPTION


## issue information
https://www.notion.so/Update-DataSheet-KeyValue-30c68a0d1d7a8069a625f385170f0f84
<!--
* githubのissueタイトルとURL
* slackでのコミュニケーションログ
* Notionでの関連ドキュメントリンクなど
-->

## Overview
Add trailingContent prop to DataSheet.KeyValue for right-aligned secondary text like dates and metadata. This is needed for Regulatory Screening history tab in sds_scan_general
<!--
* 変更の理由や内容の説明
-->
## Dependencies
<!--
* 変更の影響を受けると考えられる機能や環境
-->

## Step to test
<!--
* 動作確認手順
-->

## Additional information
http://localhost:6006/?path=/story/components-datasheet--key-value-with-trailing-content
<img width="997" height="416" alt="Screenshot 2026-05-15 at 11 11 32" src="https://github.com/user-attachments/assets/1114f754-98ec-4fca-8389-8e552537b697" />

<!--
* 特にレビューしてほしいポイントなどの補足情報
-->
