### PR TITLE
fix(multiple): Improve content overflow handling

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -24,7 +24,7 @@ const dropdownContentVariants = cva(
 );
 
 const dropdownItemVariants = cva(
-  `focus:bg-interactive-neutral-hover px-md h-10 py-1.5 relative flex
+  `focus:bg-interactive-neutral-hover px-md min-h-10 py-1.5 relative flex
   cursor-pointer items-center transition-colors outline-none select-none
   data-[disabled]:pointer-events-none data-[disabled]:opacity-50`,
   {

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { cn } from '../../utils';
+
 export interface FormFieldProps {
   label?: React.ReactNode;
   children?: React.ReactNode;
@@ -31,7 +33,7 @@ export const FormField: React.FC<FormFieldProps> = ({
     : children;
 
   return (
-    <div className={className}>
+    <div className={cn('min-w-0', className)}>
       {label && (
         <label
           htmlFor={name}

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -760,6 +760,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
     return {
       minWidth: effectiveMinWidth,
       maxWidth: effectiveMaxWidth,
+      popoverMaxWidth: maxWidth || '32rem',
       width: autoSize ? 'auto' : '100%',
     };
   };
@@ -991,7 +992,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
             popoverClassName
           )}
           style={{
-            maxWidth: `min(${widthConstraints.maxWidth}, 85vw)`,
+            maxWidth: `min(${widthConstraints.popoverMaxWidth}, 85vw)`,
             maxHeight: screenSize === 'mobile' ? '70vh' : '60vh',
             touchAction: 'manipulation',
           }}
@@ -1082,11 +1083,13 @@ const MultiSelectInner = <T extends string | number = string | number>(
                           disabled={Boolean(option.disabled)}
                         >
                           <Checkbox className="mr-xs" checked={isSelected} />
-                          {effectiveRenderOption({
-                            option,
-                            location: 'dropdown',
-                            isSelected,
-                          })}
+                          <span className="min-w-0 overflow-hidden">
+                            {effectiveRenderOption({
+                              option,
+                              location: 'dropdown',
+                              isSelected,
+                            })}
+                          </span>
                         </CommandItem>
                       );
                     })}
@@ -1116,11 +1119,13 @@ const MultiSelectInner = <T extends string | number = string | number>(
                         disabled={Boolean(option.disabled)}
                       >
                         <Checkbox className="mr-xs" checked={isSelected} />
-                        {effectiveRenderOption({
-                          option,
-                          location: 'dropdown',
-                          isSelected,
-                        })}
+                        <span className="min-w-0 overflow-hidden">
+                          {effectiveRenderOption({
+                            option,
+                            location: 'dropdown',
+                            isSelected,
+                          })}
+                        </span>
                       </CommandItem>
                     );
                   })}

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -228,7 +228,7 @@ export const WithNumericValues: StoryFn = () => {
 };
 
 export const LongOptionLabels: StoryFn = () => (
-  <div className="space-y-8">
+  <div className="max-w-80 space-y-8">
     <div>
       <h3 className="text-lg font-semibold mb-4">
         Long Labels (Default Variant)

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -19,7 +19,8 @@ const selectVariants = cva(
       variant: {
         default: 'border-interactive-default p-md rounded gap-xs h-11.5 w-full',
         compact: `py-xxs px-xs rounded-sm gap-xxs
-        hover:bg-interactive-neutral-hover h-[26px] w-fit border-transparent`,
+        hover:bg-interactive-neutral-hover max-w-62 h-[26px] w-fit
+        border-transparent`,
       },
       intent: {
         primary: '',
@@ -50,14 +51,14 @@ const selectVariants = cva(
 );
 
 const selectContentVariants = cva(
-  `bg-surface-primary z-dropdown relative w-full
-  max-w-[var(--radix-select-trigger-width)]
-  min-w-[var(--radix-select-trigger-width)] overflow-hidden border`,
+  'bg-surface-primary z-dropdown relative overflow-hidden border',
   {
     variants: {
       variant: {
-        default: 'border-interactive-default max-h-96 rounded',
+        default: `border-interactive-default max-h-96 rounded
+        w-[var(--radix-select-trigger-width)]`,
         compact: `border-divider-default rounded-sm
+        min-w-[max(12rem,var(--radix-select-trigger-width))]
         shadow-[0px_5px_9px_0px_rgba(0,0,0,0.16)]`,
       },
     },
@@ -70,7 +71,7 @@ const selectContentVariants = cva(
 const selectItemVariants = cva(
   `disabled:bg-surface-disabled disabled:text-interactive-disabled
   data-[disabled]:text-interactive-disabled flex cursor-pointer items-center
-  border-0 ring-0 focus:outline-0 disabled:cursor-not-allowed
+  border-0 wrap-anywhere ring-0 focus:outline-0 disabled:cursor-not-allowed
   data-[disabled]:cursor-not-allowed`,
   {
     variants: {
@@ -181,20 +182,22 @@ export const Select = <T extends number | string = string>({
           className
         )}
       >
-        <div className="inline-flex items-center">
+        <div className="inline-flex items-center truncate">
           {renderIcon(Icon, {
-            className: cn('text-body-secondary mr-xxs h-3.5 w-3.5'),
+            className: cn('shrink-0 text-body-secondary mr-xxs h-3.5 w-3.5'),
           })}
-          <RadixSelect.Value
-            placeholder={placeholder || 'Select an option'}
-            className={cn({
-              'text-sm': variant === 'compact',
-            })}
-          />
+          <span className="truncate text-ellipsis">
+            <RadixSelect.Value
+              placeholder={placeholder || 'Select an option'}
+              className={cn('hidden', {
+                'text-sm': variant === 'compact',
+              })}
+            />
+          </span>
         </div>
         {!hideChevron && (
           <RadixSelect.Icon
-            className={cn('text-body-primary h-3.5 w-3.5', {
+            className={cn('text-body-primary h-3.5 w-3.5 shrink-0', {
               'text-body-disabled': props.disabled,
             })}
           >

--- a/src/lib/components/Command/Command.tsx
+++ b/src/lib/components/Command/Command.tsx
@@ -124,7 +124,7 @@ const CommandItem = React.forwardRef<
       `hover:bg-interactive-neutral-hover
       data-[selected=true]:bg-interactive-neutral-hover
       data-[selected=true]:text-body-primary px-lg min-h-10 py-1.5 relative flex
-      cursor-default items-center outline-none select-none
+      cursor-default items-center wrap-anywhere outline-none select-none
       data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50`,
       className
     )}


### PR DESCRIPTION
## Issue information

Content in Select, MultiSelect, and related dropdown components could overflow their containers, causing visual issues like tag borders touching popover edges and dropdowns growing too wide.

## Overview

- **Select**: Constrain dropdown width with max-w cap, add wrap-anywhere for long option labels, truncate trigger text, prevent icon shrinking
- **MultiSelect**: Separate popover max-width from trigger width so the trigger stays full-width while the popover is capped at 32rem. Wrap dropdown option content to prevent tag borders touching popover edges
- **Command**: Add wrap-anywhere to CommandItem for proper word breaking in constrained widths
- **DropdownMenu**: Use min-h instead of fixed h so items can grow when content wraps
- **FormField**: Add min-w-0 to prevent flex overflow

## Dependencies

Affects all components using Select, MultiSelect, DropdownMenu, and FormField.

## Steps to Test

- Open Select stories with long option labels and verify text wraps / dropdown width is capped
- Open MultiSelect with a custom renderOption that renders Tags and verify tag borders don't touch the popover edge
- Verify MultiSelect trigger remains full-width while popover is constrained
- Check compact Select variant dropdown has a reasonable min/max width