### PR TITLE
feat(select): Add search bar for selects with many options

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -289,6 +289,68 @@ export const LongOptionLabels: StoryFn = () => (
   </div>
 );
 
+export const WithSearch: StoryFn = () => {
+  const [value, setValue] = React.useState<string>();
+
+  const options = [
+    { value: 'apple', label: 'Apple' },
+    { value: 'banana', label: 'Banana' },
+    { value: 'cherry', label: 'Cherry' },
+    { value: 'dragonfruit', label: 'Dragonfruit' },
+    { value: 'elderberry', label: 'Elderberry' },
+    { value: 'fig', label: 'Fig' },
+    { value: 'grape', label: 'Grape' },
+    { value: 'honeydew', label: 'Honeydew' },
+    { value: 'kiwi', label: 'Kiwi' },
+    { value: 'lemon', label: 'Lemon' },
+    { value: 'mango', label: 'Mango' },
+    { value: 'nectarine', label: 'Nectarine' },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h3 className="text-lg font-semibold mb-4">
+          With Search (12 options, threshold is 7)
+        </h3>
+        <p className="text-sm mb-4">
+          Selected: <strong>{value ?? 'none'}</strong>
+        </p>
+        <Select
+          variant="default"
+          options={options}
+          value={value}
+          onValueChange={setValue}
+          placeholder="Select a fruit"
+        />
+      </div>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-4">
+          Without Search (fewer than 10 options)
+        </h3>
+        <Select
+          variant="default"
+          options={options.slice(0, 5)}
+          placeholder="Select a fruit"
+        />
+      </div>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-4">
+          Compact Variant With Search
+        </h3>
+        <Select
+          variant="compact"
+          icon={IconBuilding}
+          options={options}
+          placeholder="Select a fruit"
+        />
+      </div>
+    </div>
+  );
+};
+
 export const IsolatedVsFormField: StoryFn = () => (
   <div className="space-y-8">
     <div>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { Select as RadixSelect } from 'radix-ui';
-import { IconChevronDown } from '@tabler/icons-react';
+import { IconChevronDown, IconSearch } from '@tabler/icons-react';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 
 import type { IconProp } from '../../lib/utils';
 import { cn, renderIcon } from '../../lib/utils';
+
+const SEARCH_ITEM_THRESHOLD = 7;
 
 const selectVariants = cva(
   `bg-surface-primary text-body-primary disabled:border-interactive-disabled
@@ -57,7 +59,7 @@ const selectContentVariants = cva(
       variant: {
         default: `border-interactive-default max-h-96 rounded
         w-[var(--radix-select-trigger-width)]`,
-        compact: `border-divider-default rounded-sm
+        compact: `border-divider-default max-h-96 rounded-sm
         min-w-[max(12rem,var(--radix-select-trigger-width))]
         shadow-[0px_5px_9px_0px_rgba(0,0,0,0.16)]`,
       },
@@ -132,6 +134,7 @@ export interface SelectProps<T extends number | string = string>
   onValueChange?: (value: T) => void;
   intent?: 'primary' | 'secondary';
   hideChevron?: boolean;
+  searchPlaceholder?: string;
 }
 
 export const Select = <T extends number | string = string>({
@@ -145,8 +148,45 @@ export const Select = <T extends number | string = string>({
   value,
   hideChevron = false,
   onValueChange,
+  searchPlaceholder = 'Search...',
   ...props
 }: SelectProps<T>) => {
+  const [searchValue, setSearchValue] = React.useState('');
+  const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+  const selectableOptions = options.filter(
+    (opt) => !('type' in opt) || opt.type === 'Option' || opt.type === undefined
+  );
+  const showSearch = selectableOptions.length >= SEARCH_ITEM_THRESHOLD;
+
+  const getTextContent = (node: React.ReactNode): string => {
+    if (typeof node === 'string') return node;
+    if (typeof node === 'number') return String(node);
+    if (Array.isArray(node)) return node.map(getTextContent).join('');
+    if (React.isValidElement(node)) {
+      const { children } = node.props as { children?: React.ReactNode };
+      if (children) return getTextContent(children);
+    }
+    return '';
+  };
+
+  const filteredOptions =
+    showSearch && searchValue
+      ? options.filter((opt) => {
+          if (
+            'type' in opt &&
+            (opt.type === 'Group' || opt.type === 'Separator')
+          )
+            return true;
+          if ('label' in opt) {
+            return getTextContent(opt.label)
+              .toLowerCase()
+              .includes(searchValue.toLowerCase());
+          }
+          return true;
+        })
+      : options;
+
   const rootProps: React.ComponentProps<typeof RadixSelect.Root> = {
     ...props,
   };
@@ -174,7 +214,13 @@ export const Select = <T extends number | string = string>({
   }
 
   return (
-    <RadixSelect.Root {...rootProps}>
+    <RadixSelect.Root
+      {...rootProps}
+      onOpenChange={(open) => {
+        if (!open) setSearchValue('');
+        rootProps.onOpenChange?.(open);
+      }}
+    >
       <RadixSelect.Trigger
         className={cn(
           selectVariants({ variant, intent, invalid }),
@@ -214,9 +260,26 @@ export const Select = <T extends number | string = string>({
           sideOffset={-1} // Needed to not have the 1px spacing because of the borders.
           className={cn(selectContentVariants({ variant }), className)}
         >
+          {showSearch && (
+            <div
+              className="border-divider-default gap-xs px-md py-xs flex
+                items-center border-b"
+            >
+              <IconSearch className="text-body-secondary h-3.5 w-3.5 shrink-0" />
+              <input
+                ref={searchInputRef}
+                className="text-body-primary placeholder:text-body-placeholder
+                  w-full bg-transparent outline-none"
+                placeholder={searchPlaceholder}
+                value={searchValue}
+                onChange={(e) => setSearchValue(e.target.value)}
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+            </div>
+          )}
           <RadixSelect.ScrollUpButton />
           <RadixSelect.Viewport>
-            {options.map((option, index) => {
+            {filteredOptions.map((option, index) => {
               switch (option.type) {
                 case 'Group':
                   return (

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -7,8 +7,6 @@ import { cva } from 'class-variance-authority';
 import type { IconProp } from '../../lib/utils';
 import { cn, renderIcon } from '../../lib/utils';
 
-const SEARCH_ITEM_THRESHOLD = 7;
-
 const selectVariants = cva(
   `bg-surface-primary text-body-primary disabled:border-interactive-disabled
   disabled:bg-surface-disabled disabled:text-body-disabled
@@ -135,6 +133,7 @@ export interface SelectProps<T extends number | string = string>
   intent?: 'primary' | 'secondary';
   hideChevron?: boolean;
   searchPlaceholder?: string;
+  searchThreshold?: number;
 }
 
 export const Select = <T extends number | string = string>({
@@ -149,6 +148,7 @@ export const Select = <T extends number | string = string>({
   hideChevron = false,
   onValueChange,
   searchPlaceholder = 'Search...',
+  searchThreshold = 7,
   ...props
 }: SelectProps<T>) => {
   const [searchValue, setSearchValue] = React.useState('');
@@ -157,7 +157,7 @@ export const Select = <T extends number | string = string>({
   const selectableOptions = options.filter(
     (opt) => !('type' in opt) || opt.type === 'Option' || opt.type === undefined
   );
-  const showSearch = selectableOptions.length >= SEARCH_ITEM_THRESHOLD;
+  const showSearch = selectableOptions.length >= searchThreshold;
 
   const getTextContent = (node: React.ReactNode): string => {
     if (typeof node === 'string') return node;
@@ -170,22 +170,17 @@ export const Select = <T extends number | string = string>({
     return '';
   };
 
-  const filteredOptions =
-    showSearch && searchValue
-      ? options.filter((opt) => {
-          if (
-            'type' in opt &&
-            (opt.type === 'Group' || opt.type === 'Separator')
-          )
-            return true;
-          if ('label' in opt) {
-            return getTextContent(opt.label)
-              .toLowerCase()
-              .includes(searchValue.toLowerCase());
-          }
-          return true;
-        })
-      : options;
+  const isOptionVisible = (opt: SelectOption<T>): boolean => {
+    if (!showSearch || !searchValue) return true;
+    if ('type' in opt && (opt.type === 'Group' || opt.type === 'Separator'))
+      return true;
+    if ('label' in opt) {
+      return getTextContent(opt.label)
+        .toLowerCase()
+        .includes(searchValue.toLowerCase());
+    }
+    return true;
+  };
 
   const rootProps: React.ComponentProps<typeof RadixSelect.Root> = {
     ...props,
@@ -279,11 +274,15 @@ export const Select = <T extends number | string = string>({
           )}
           <RadixSelect.ScrollUpButton />
           <RadixSelect.Viewport>
-            {filteredOptions.map((option, index) => {
+            {options.map((option, index) => {
+              const visible = isOptionVisible(option);
               switch (option.type) {
                 case 'Group':
                   return (
-                    <RadixSelect.Group key={index}>
+                    <RadixSelect.Group
+                      key={index}
+                      className={cn(!visible && 'hidden')}
+                    >
                       <RadixSelect.Label>{option.label}</RadixSelect.Label>
                     </RadixSelect.Group>
                   );
@@ -291,7 +290,10 @@ export const Select = <T extends number | string = string>({
                   return (
                     <RadixSelect.Separator
                       key={index}
-                      className="border-divider-default h-px border-b"
+                      className={cn(
+                        'border-divider-default h-px border-b',
+                        !visible && 'hidden'
+                      )}
                     />
                   );
                 default:
@@ -300,10 +302,13 @@ export const Select = <T extends number | string = string>({
                       key={index}
                       value={String(option.value)}
                       disabled={option.disabled ?? false}
-                      className={selectItemVariants({
-                        variant,
-                        isSelected: value === option.value,
-                      })}
+                      className={cn(
+                        selectItemVariants({
+                          variant,
+                          isSelected: value === option.value,
+                        }),
+                        !visible && 'hidden'
+                      )}
                     >
                       {renderIcon(option.icon, {
                         className: cn('h-5 w-5', {


### PR DESCRIPTION
## Issue information

<img width="286" height="508" alt="image" src="https://github.com/user-attachments/assets/bcdc330a-2ff8-4e65-ac5c-d686a34c4e93" />
<img width="338" height="212" alt="image" src="https://github.com/user-attachments/assets/beadb6a9-8f71-446d-b4a4-a11e87b6cb5c" />

## Overview

Adds a search input to the Select dropdown when the number of selectable options reaches the `SEARCH_ITEM_THRESHOLD` (default: 7). This improves usability for selects with many items by allowing users to filter options by typing.

Changes:
- Search input with icon, shown only when option count >= threshold
- Filters options by extracting text content from `React.ReactNode` labels
- Search resets when dropdown closes
- New `searchPlaceholder` prop for customization
- Added `max-h-96` to compact variant for consistent scroll behavior

## Dependencies

None

## Steps to Test

- Open Storybook, navigate to Components/Select/WithSearch
- Verify the search bar appears for the 12-option select but not the 5-option select
- Type in the search bar and confirm options filter correctly
- Select an option, reopen - search should be cleared
- Test compact variant search as well