### PR TITLE
feat(multiselect): Add creatable option for custom values

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -898,3 +898,35 @@ export const InlineSelectionComparison: Story = {
     },
   },
 };
+
+export const Creatable: Story = {
+  args: {
+    options: basicOptions,
+    placeholder: 'Select or create...',
+    searchPlaceholder: 'Add or search...',
+    creatable: true,
+    creatableLabel: (value: string) => `Add '${value}'`,
+    customGroupLabel: 'New items',
+    existingGroupLabel: 'Existing items',
+    onValueChange: (value: unknown[]) => console.log('Changed:', value),
+    onApplySelection: (value: unknown[]) => console.log('Applied:', value),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `creatable` is enabled, the search input doubles as a creation input. Typing a value that does not exist in the options shows an "Add \'value\'" suggestion at the top. Once selected, the custom item appears in a "New items" group. Custom items are removed when deselected and the selection is applied.',
+      },
+      source: {
+        code: `import { MultiSelect } from '@chemican/components';
+
+<MultiSelect
+  options={options}
+  placeholder="Select or create..."
+  searchPlaceholder="Add or search..."
+  creatable
+/>`,
+      },
+    },
+  },
+};

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { IconChevronDown } from '@tabler/icons-react';
+import { IconChevronDown, IconPlus } from '@tabler/icons-react';
 
 import { cn } from '../../lib/utils';
 import { Button } from '../Button';
@@ -350,6 +350,34 @@ interface MultiSelectProps<T = string | number>
   onValueChange?: (value: T[]) => void;
 
   /**
+   * If true, allows the user to create new custom values via the search input.
+   * An "Add '{value}'" suggestion appears when typing a value that doesn't exist.
+   * Custom values are shown in a separate group and removed when deselected and applied.
+   * Optional, defaults to false.
+   */
+  creatable?: boolean;
+
+  /**
+   * Label template for the create option suggestion.
+   * Receives the search value as a parameter.
+   * Optional, defaults to (value) => `「${value}」を追加`.
+   */
+  creatableLabel?: (value: string) => React.ReactNode;
+
+  /**
+   * Heading for the group containing custom-created items.
+   * Optional, defaults to "新しい項目".
+   */
+  customGroupLabel?: string;
+
+  /**
+   * Heading for the group containing the original options when custom items exist.
+   * Only shown when there are custom items to distinguish them from existing ones.
+   * Optional, defaults to "既存の項目".
+   */
+  existingGroupLabel?: string;
+
+  /**
    * Callback fired when the Apply button is clicked in the popover footer.
    * Receives the array of currently selected values.
    * Optional, called only when user confirms their selection.
@@ -425,6 +453,10 @@ const MultiSelectInner = <T extends string | number = string | number>(
     customTrigger,
     selectionDisplayMode = 'default',
     hideSelection = false,
+    creatable = false,
+    creatableLabel = (value: string) => `「${value}」を追加`,
+    customGroupLabel = '新しい項目',
+    existingGroupLabel = '既存の項目',
     ...props
   }: MultiSelectProps<T>,
   ref: React.Ref<MultiSelectRef<T>>
@@ -432,6 +464,9 @@ const MultiSelectInner = <T extends string | number = string | number>(
   const [selectedValues, setSelectedValues] = React.useState<T[]>(defaultValue);
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
   const [searchValue, setSearchValue] = React.useState('');
+  const [customOptions, setCustomOptions] = React.useState<
+    MultiSelectOption<T>[]
+  >([]);
 
   const [politeMessage, setPoliteMessage] = React.useState('');
   const [assertiveMessage, setAssertiveMessage] = React.useState('');
@@ -478,6 +513,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
 
   const resetToDefault = React.useCallback(() => {
     setSelectedValues(defaultValue);
+    setCustomOptions([]);
     setIsPopoverOpen(false);
     setSearchValue('');
     onValueChange(defaultValue);
@@ -571,13 +607,18 @@ const MultiSelectInner = <T extends string | number = string | number>(
   const responsiveSettings = getResponsiveSettings();
 
   const getAllOptions = React.useCallback((): MultiSelectOption<T>[] => {
-    if (options.length === 0) return [];
-    let allOptions: MultiSelectOption<T>[];
-    if (isGroupedOptions(options)) {
-      allOptions = options.flatMap((group) => group.options);
+    let baseOptions: MultiSelectOption<T>[];
+    if (options.length === 0) {
+      baseOptions = [];
+    } else if (isGroupedOptions(options)) {
+      baseOptions = options.flatMap((group) => group.options);
     } else {
-      allOptions = options;
+      baseOptions = options as MultiSelectOption<T>[];
     }
+
+    // Include custom options
+    const allOptions = [...baseOptions, ...customOptions];
+
     const valueSet = new Set<T>();
     const duplicates: T[] = [];
     const uniqueOptions: MultiSelectOption<T>[] = [];
@@ -606,7 +647,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
       );
     }
     return deduplicateOptions ? uniqueOptions : allOptions;
-  }, [options, deduplicateOptions, isGroupedOptions]);
+  }, [options, deduplicateOptions, isGroupedOptions, customOptions]);
 
   const getOptionByValue = React.useCallback(
     (value: T): MultiSelectOption<T> | undefined => {
@@ -671,9 +712,36 @@ const MultiSelectInner = <T extends string | number = string | number>(
     }
   };
 
+  const handleCreateOption = (value: string) => {
+    if (disabled || !creatable) return;
+    const typedValue = value as T;
+    const newOption: MultiSelectOption<T> = {
+      value: typedValue,
+      label: value,
+    };
+    setCustomOptions((prev) => [...prev, newOption]);
+    const newSelectedValues = [...selectedValues, typedValue];
+    setSelectedValues(newSelectedValues);
+    onValueChange(newSelectedValues);
+    setSearchValue('');
+    if (closeOnSelect) {
+      setIsPopoverOpen(false);
+    }
+  };
+
+  const purgeUnselectedCustomOptions = React.useCallback(
+    (currentSelected: T[]) => {
+      setCustomOptions((prev) =>
+        prev.filter((opt) => currentSelected.includes(opt.value))
+      );
+    },
+    []
+  );
+
   const handleClear = () => {
     if (disabled) return;
     setSelectedValues([]);
+    setCustomOptions([]);
     onApplySelection([]);
     onValueChange([]);
   };
@@ -741,6 +809,22 @@ const MultiSelectInner = <T extends string | number = string | number>(
 
   // Use provided renderOption or fall back to default
   const effectiveRenderOption = renderOption || defaultRenderOption;
+
+  const showCreateOption = React.useMemo(() => {
+    if (!creatable || !searchValue.trim()) return false;
+    const trimmed = searchValue.trim();
+    const allOpts = getAllOptions();
+    return !allOpts.some(
+      (opt) =>
+        String(opt.value).toLowerCase() === trimmed.toLowerCase() ||
+        opt.label.toLowerCase() === trimmed.toLowerCase()
+    );
+  }, [creatable, searchValue, getAllOptions]);
+
+  const selectedCustomOptions = React.useMemo(
+    () => customOptions.filter((opt) => selectedValues.includes(opt.value)),
+    [customOptions, selectedValues]
+  );
 
   React.useEffect(() => {
     if (!resetOnDefaultValueChange) return;
@@ -1011,6 +1095,9 @@ const MultiSelectInner = <T extends string | number = string | number>(
                   onValueChange={setSearchValue}
                   aria-label={searchAriaLabel}
                   aria-describedby={`${multiSelectId}-search-help`}
+                  {...(creatable && {
+                    icon: <IconPlus className="mr-xxs h-3.5 w-3.5 shrink-0" />,
+                  })}
                 />
               </header>
             )}
@@ -1022,7 +1109,25 @@ const MultiSelectInner = <T extends string | number = string | number>(
               )}
               style={{ overscrollBehaviorY: 'contain' }}
             >
-              <CommandEmpty>{emptyIndicator}</CommandEmpty>
+              {!showCreateOption && (
+                <CommandEmpty>{emptyIndicator}</CommandEmpty>
+              )}
+
+              {showCreateOption && (
+                <CommandGroup>
+                  <CommandItem
+                    key="__create__"
+                    value={`__create__:${searchValue.trim()}`}
+                    onSelect={() => handleCreateOption(searchValue.trim())}
+                    className="cursor-pointer"
+                  >
+                    <IconPlus className="mr-xs h-4 w-4" />
+                    <span className="italic">
+                      {creatableLabel(searchValue.trim())}
+                    </span>
+                  </CommandItem>
+                </CommandGroup>
+              )}
 
               {!hideSelectAll && !searchValue && (
                 <CommandGroup>
@@ -1058,6 +1163,34 @@ const MultiSelectInner = <T extends string | number = string | number>(
                   </CommandItem>
                 </CommandGroup>
               )}
+
+              {selectedCustomOptions.length > 0 && (
+                <CommandGroup heading={customGroupLabel}>
+                  {selectedCustomOptions.map((option) => {
+                    const isSelected = selectedValues.includes(option.value);
+                    return (
+                      <CommandItem
+                        key={`custom-${option.value}`}
+                        value={`${option.value}:${option.label}`}
+                        onSelect={() => toggleOption(option.value)}
+                        role="option"
+                        aria-selected={isSelected}
+                        className="cursor-pointer"
+                      >
+                        <Checkbox className="mr-xs" checked={isSelected} />
+                        <span className="min-w-0 overflow-hidden">
+                          {effectiveRenderOption({
+                            option,
+                            location: 'dropdown',
+                            isSelected,
+                          })}
+                        </span>
+                      </CommandItem>
+                    );
+                  })}
+                </CommandGroup>
+              )}
+
               {isGroupedOptions(options) ? (
                 options.map((group) => (
                   <CommandGroup key={group.heading} heading={group.heading}>
@@ -1096,7 +1229,13 @@ const MultiSelectInner = <T extends string | number = string | number>(
                   </CommandGroup>
                 ))
               ) : (
-                <CommandGroup>
+                <CommandGroup
+                  heading={
+                    selectedCustomOptions.length > 0
+                      ? existingGroupLabel
+                      : undefined
+                  }
+                >
                   {options.map((option) => {
                     const isSelected = selectedValues.includes(option.value);
                     return (
@@ -1153,6 +1292,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
                   size="xs"
                   className="min-w-auto"
                   onClick={() => {
+                    purgeUnselectedCustomOptions(selectedValues);
                     onApplySelection(selectedValues);
                     setIsPopoverOpen(false);
                   }}

--- a/src/lib/components/Command/Command.tsx
+++ b/src/lib/components/Command/Command.tsx
@@ -25,8 +25,10 @@ Command.displayName = CommandPrimitive.displayName;
 
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input> & {
+    icon?: React.ReactNode;
+  }
+>(({ className, icon, ...props }, ref) => (
   <div
     className="border-divider-default py-sm px-md flex items-center border-b"
     cmdk-input-wrapper=""
@@ -41,7 +43,7 @@ const CommandInput = React.forwardRef<
         has-[:focus]:border-[var(--chemican-green-800)] has-[:focus]:ring-4
         has-[:focus]:outline-0"
     >
-      <IconSearch className="mr-xxs h-3.5 w-3.5 shrink-0" />
+      {icon ?? <IconSearch className="mr-xxs h-3.5 w-3.5 shrink-0" />}
       <CommandPrimitive.Input
         ref={ref}
         className={cn(


### PR DESCRIPTION
## Issue information
<img width="405" height="472" alt="image" src="https://github.com/user-attachments/assets/57e68ac0-8649-4ac8-a5aa-d9095c96652f" />

## Overview

Adds a `creatable` feature to MultiSelect that allows users to create new custom values on the fly via the search input.

**New props:**
- `creatable` - enables the feature
- `creatableLabel` - customizes the create suggestion text (default: `「{value}」を追加`)
- `customGroupLabel` - heading for custom items group (default: `新しい項目`)
- `existingGroupLabel` - heading for existing items when custom items are present (default: `既存の項目`)

**Behavior:**
- Search input shows a plus icon instead of magnifying glass when `creatable` is enabled
- Typing a value not matching any existing option shows an italic "Add 'value'" suggestion with a plus icon
- Created items appear in a "New items" group between select-all and existing options
- Existing options get an "Existing items" heading when custom items are present
- Custom items are purged when deselected and the selection is applied/cleared/reset

**Also adds** an optional `icon` prop to `CommandInput` to allow overriding the default search icon.

## Dependencies

- None

## Steps to Test

- Open Storybook and navigate to MultiSelect > Creatable
- Type a value not in the options list and verify the "Add" suggestion appears
- Select the custom value and verify it appears in "New items" group
- Verify existing options get an "Existing items" heading
- Deselect the custom value, click close, reopen - verify it's gone
- Verify "Select All" remains at the top, above both groups