### PR TITLE
fix(multiple): Replace hardcoded green tokens with semantic theme-aware tokens

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,10 +1,27 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { Preview } from '@storybook/react-vite';
 
 import '../src/bundle.css';
 import { TooltipProvider } from '../src/components/Tooltip';
 
 const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: 'Global color theme',
+      toolbar: {
+        title: 'Theme',
+        icon: 'paintbrush',
+        items: [
+          { value: '', title: 'SDS Manager theme' },
+          { value: 'Blue Mode', title: 'Delivery Manager theme' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: '',
+  },
   parameters: {
     options: {
       storySort: {
@@ -24,11 +41,24 @@ const preview: Preview = {
   },
   tags: ['autodocs'],
   decorators: [
-    (Story) => (
-      <TooltipProvider>
-        <Story />
-      </TooltipProvider>
-    ),
+    (Story, context) => {
+      const theme = context.globals.theme;
+
+      useEffect(() => {
+        const root = document.documentElement;
+        if (theme) {
+          root.setAttribute('data-theme', theme);
+        } else {
+          root.removeAttribute('data-theme');
+        }
+      }, [theme]);
+
+      return (
+        <TooltipProvider>
+          <Story />
+        </TooltipProvider>
+      );
+    },
   ],
 };
 

--- a/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -53,7 +53,7 @@ const Linear = React.forwardRef<HTMLDivElement, LinearProgressProps>(
       >
         <RadixProgress.Indicator
           className={cn(
-            'bg-shape-accent-green-strong h-full transition-transform',
+            'bg-shape-interactive-primary-default h-full transition-transform',
             {
               'animate-indeterminate': indeterminate,
             }
@@ -141,7 +141,7 @@ const Circular = React.forwardRef<HTMLDivElement, CircularProgressProps>(
             cx="50"
             cy="50"
             r={radii[size]}
-            stroke="var(--token-color-shape-accent-green-strong)"
+            stroke="var(--token-color-shape-interactive-primary-default)"
             strokeWidth={strokeWidths[size]}
             strokeLinecap="round"
             strokeDasharray="141.37 282.74"

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -26,10 +26,9 @@ const Switch = React.forwardRef<
         data-[state=unchecked]:disabled:bg-interactive-disabled h-6 w-10
         data-[state=checked]:enabled:hover:bg-shape-interactive-primary-hover
         data-[state=unchecked]:enabled:hover:bg-shape-accent-gray-strong
-        inline-flex shrink-0 cursor-pointer items-center rounded-full
-        transition-all outline-none focus-visible:ring-[3px]
-        focus-visible:ring-[var(--token-color-background-interactive-neutral-active)]
-        disabled:cursor-not-allowed`,
+        focus-visible:ring-interactive-focused inline-flex shrink-0
+        cursor-pointer items-center rounded-full transition-all outline-none
+        focus-visible:ring-[3px] disabled:cursor-not-allowed`,
         className
       )}
       {...props}

--- a/src/components/TabBar/TabBar.tsx
+++ b/src/components/TabBar/TabBar.tsx
@@ -29,14 +29,14 @@ const tabBarVariants = cva('inline-flex', {
 const tabVariants = cva(
   `text-body-primary border-divider-default data-[state=active]:font-bold
   disabled:text-interactive-disabled after:left-0 after:h-0
-  disabled:hover:after:h-0 relative inline-flex cursor-pointer items-center
-  justify-center border-b leading-[100%] tracking-[0] whitespace-nowrap
-  transition-colors after:absolute after:bottom-[-1px] after:w-full
-  after:transition-all after:content-[''] hover:after:h-[2px]
-  hover:after:bg-[var(--chemican-green-800)] disabled:cursor-not-allowed
-  data-[state=active]:text-[var(--chemican-green-800)]
-  data-[state=active]:after:h-[2px]
-  data-[state=active]:after:bg-[var(--chemican-green-800)]`,
+  disabled:hover:after:h-0 hover:after:bg-shape-interactive-primary-default
+  data-[state=active]:text-interactive-primary-default
+  data-[state=active]:after:bg-shape-interactive-primary-selected relative
+  inline-flex cursor-pointer items-center justify-center border-b leading-[100%]
+  tracking-[0] whitespace-nowrap transition-colors after:absolute
+  after:bottom-[-1px] after:w-full after:transition-all after:content-['']
+  hover:after:h-[2px] disabled:cursor-not-allowed
+  data-[state=active]:after:h-[2px]`,
   {
     variants: {
       size: {
@@ -52,9 +52,9 @@ const tabVariants = cva(
 
 // More button variants
 const moreButtonVariants = cva(
-  `text-body-primary border-divider-default relative inline-flex cursor-pointer
-  items-center justify-center border-b leading-[100%] tracking-[0]
-  whitespace-nowrap transition-colors hover:text-[var(--chemican-green-800)]`,
+  `text-body-primary border-divider-default hover:text-interactive-primary-hover
+  relative inline-flex cursor-pointer items-center justify-center border-b
+  leading-[100%] tracking-[0] whitespace-nowrap transition-colors`,
   {
     variants: {
       size: {
@@ -239,7 +239,7 @@ export const TabBar = React.forwardRef<
                   className={cn(
                     moreButtonVariants({ size: effectiveSize }),
                     activeInOverflow &&
-                      'font-bold text-[var(--chemican-green-800)]'
+                      'font-bold text-interactive-primary-default'
                   )}
                 >
                   <IconDotsVertical
@@ -254,7 +254,7 @@ export const TabBar = React.forwardRef<
                   const { value, disabled, asChild, children } = tab.props;
                   const itemClassName = cn(
                     value === activeValue &&
-                      'font-bold text-[var(--chemican-green-800)]'
+                      'font-bold text-interactive-primary-default'
                   );
 
                   if (asChild && React.isValidElement(children)) {

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -10,9 +10,8 @@ export const inputWrapperVariants = cva(
   `border-interactive-default bg-surface-primary
   has-[>input:enabled]:hover:border-interactive-hover
   has-[:disabled]:bg-surface-disabled has-[:focus]:ring-interactive-focused
-  h-11.5 rounded relative flex w-full items-center border
-  has-[:focus]:border-[var(--chemican-green-800)] has-[:focus]:ring-4
-  has-[:focus]:outline-0`,
+  h-11.5 rounded has-[:focus]:border-interactive-primary-default relative flex
+  w-full items-center border has-[:focus]:ring-4 has-[:focus]:outline-0`,
   {
     variants: {
       invalid: {


### PR DESCRIPTION
## Issue information

Components using hardcoded primitive color tokens instead of semantic design tokens, causing them to remain green regardless of the active theme (Green Mode vs Blue Mode).

## Overview

Several components referenced `--chemican-green-800` or `accent-green-strong` directly instead of using semantic interactive tokens that change per theme. This PR replaces all occurrences with the correct theme-aware tokens:

- **TabBar**: Active/hover text and underline now use `text-interactive-primary-*` and `bg-shape-interactive-primary-*`
- **TextField**: Focus border now uses `border-interactive-primary-default`
- **ProgressIndicator**: Linear bar and circular stroke now use `shape-interactive-primary-default`
- **Switch**: Focus ring now uses `ring-interactive-focused` utility instead of a raw CSS variable

## Dependencies

- All components that display interactive primary colors are affected
- Theme switching (Green Mode / Blue Mode) should now work correctly across all components

## Steps to Test

- Open Storybook and switch between Green Mode and Blue Mode
- Verify TabBar active/hover states change color with theme
- Verify TextField focus border changes color with theme
- Verify ProgressIndicator (both linear and circular) changes color with theme
- Verify Switch focus ring changes color with theme