### PR TITLE
feat(multiselect): Add maxDisplayedOptions to truncate long lists

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -71,6 +71,10 @@ const meta: Meta<typeof MultiSelect> = {
       control: 'boolean',
       description: 'Whether to filter by both value and label when searching',
     },
+    loading: {
+      control: 'boolean',
+      description: 'Whether to show a loading indicator inside the dropdown',
+    },
   },
 };
 
@@ -942,6 +946,166 @@ export const MaxDisplayedOptions: Story = {
   options={options}
   placeholder="Select fruits..."
   maxDisplayedOptions={5}
+/>`,
+      },
+    },
+  },
+};
+
+// Full dataset that lives "on the server" for the server-side search example.
+const serverDataset: MultiSelectOption[] = Array.from(
+  { length: 60 },
+  (_, i) => ({
+    label: `SDS Document ${i + 1}`,
+    value: `sds-${i + 1}`,
+  })
+);
+
+const WithServerSideSearchComponent = () => {
+  // Only the first page of results is loaded initially.
+  const [options, setOptions] = React.useState<MultiSelectOption[]>(
+    serverDataset.slice(0, 10)
+  );
+  const [loading, setLoading] = React.useState(false);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+
+  // Simulate a server query: filter the full dataset after a short delay.
+  // Because onSearchValueChange is provided, the component skips its own
+  // client-side filtering and renders exactly what we pass back in `options`.
+  const handleSearchValueChange = (search: string) => {
+    setLoading(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      const filtered = serverDataset.filter((option) =>
+        option.label.toLowerCase().includes(search.toLowerCase())
+      );
+      setOptions(filtered.slice(0, 10));
+      setLoading(false);
+    }, 800);
+  };
+
+  return (
+    <MultiSelect
+      options={options}
+      loading={loading}
+      onSearchValueChange={handleSearchValueChange}
+      hideSelectAll
+      placeholder="Select SDS..."
+      searchPlaceholder="サーバー検索..."
+      emptyIndicator="該当する項目がありません"
+    />
+  );
+};
+
+export const WithServerSideSearch: Story = {
+  render: () => <WithServerSideSearchComponent />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Demonstrates server-side search. `onSearchValueChange` fires as the user types so the parent can fetch matching options, and `loading` shows a spinner inside the dropdown while the request is in flight. When `onSearchValueChange` is provided the built-in client-side filtering is disabled, so the parent fully controls `options`.',
+      },
+      source: {
+        code: `import { MultiSelect } from '@chemican/components';
+import { useRef, useState } from 'react';
+
+const [options, setOptions] = useState(initialOptions);
+const [loading, setLoading] = useState(false);
+const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+const handleSearchValueChange = (search: string) => {
+  setLoading(true);
+  if (timerRef.current) clearTimeout(timerRef.current);
+  timerRef.current = setTimeout(async () => {
+    const results = await fetchSdsFromServer(search); // your API call
+    setOptions(results);
+    setLoading(false);
+  }, 300);
+};
+
+<MultiSelect
+  options={options}
+  loading={loading}
+  onSearchValueChange={handleSearchValueChange}
+  hideSelectAll
+  placeholder="Select SDS..."
+/>`,
+      },
+    },
+  },
+};
+
+const WithServerSideSearchAndMaxDisplayedComponent = () => {
+  // Initial page intentionally larger than maxDisplayedOptions so the
+  // truncation hint is visible before the user starts searching.
+  const [options, setOptions] =
+    React.useState<MultiSelectOption[]>(serverDataset);
+  const [loading, setLoading] = React.useState(false);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+
+  const handleSearchValueChange = (search: string) => {
+    setLoading(true);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      const filtered = serverDataset.filter((option) =>
+        option.label.toLowerCase().includes(search.toLowerCase())
+      );
+      setOptions(filtered);
+      setLoading(false);
+    }, 800);
+  };
+
+  return (
+    <MultiSelect
+      options={options}
+      loading={loading}
+      onSearchValueChange={handleSearchValueChange}
+      maxDisplayedOptions={5}
+      moreOptionsLabel={(count) => `検索して他${count}件を表示`}
+      hideSelectAll
+      placeholder="Select SDS..."
+      searchPlaceholder="サーバー検索..."
+      emptyIndicator="該当する項目がありません"
+    />
+  );
+};
+
+export const WithServerSideSearchAndMaxDisplayed: Story = {
+  render: () => <WithServerSideSearchAndMaxDisplayedComponent />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Combines `maxDisplayedOptions` with server-side search. Before searching, only the first N server-returned options are shown with a "type to see more" hint. As soon as the user types, `onSearchValueChange` fetches matching options (with `loading` shown meanwhile) and the truncation is lifted so every returned match is visible.',
+      },
+      source: {
+        code: `import { MultiSelect } from '@chemican/components';
+import { useRef, useState } from 'react';
+
+const [options, setOptions] = useState(initialOptions);
+const [loading, setLoading] = useState(false);
+const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+const handleSearchValueChange = (search: string) => {
+  setLoading(true);
+  if (timerRef.current) clearTimeout(timerRef.current);
+  timerRef.current = setTimeout(async () => {
+    setOptions(await fetchSdsFromServer(search));
+    setLoading(false);
+  }, 300);
+};
+
+<MultiSelect
+  options={options}
+  loading={loading}
+  onSearchValueChange={handleSearchValueChange}
+  maxDisplayedOptions={5}
+  hideSelectAll
+  placeholder="Select SDS..."
 />`,
       },
     },

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -898,3 +898,52 @@ export const InlineSelectionComparison: Story = {
     },
   },
 };
+
+const manyOptions: MultiSelectOption[] = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Cherry', value: 'cherry' },
+  { label: 'Date', value: 'date' },
+  { label: 'Elderberry', value: 'elderberry' },
+  { label: 'Fig', value: 'fig' },
+  { label: 'Grape', value: 'grape' },
+  { label: 'Honeydew', value: 'honeydew' },
+  { label: 'Kiwi', value: 'kiwi' },
+  { label: 'Lemon', value: 'lemon' },
+  { label: 'Mango', value: 'mango' },
+  { label: 'Nectarine', value: 'nectarine' },
+  { label: 'Orange', value: 'orange' },
+  { label: 'Papaya', value: 'papaya' },
+  { label: 'Quince', value: 'quince' },
+  { label: 'Raspberry', value: 'raspberry' },
+  { label: 'Strawberry', value: 'strawberry' },
+  { label: 'Tangerine', value: 'tangerine' },
+  { label: 'Watermelon', value: 'watermelon' },
+  { label: 'Yuzu', value: 'yuzu' },
+];
+
+export const MaxDisplayedOptions: Story = {
+  args: {
+    options: manyOptions,
+    placeholder: 'Select fruits...',
+    maxDisplayedOptions: 5,
+    moreOptionsLabel: (count: number) => `Search to see ${count} more...`,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `maxDisplayedOptions` is set, only the first N options are shown by default. A hint indicates how many more are available. Selected items always remain visible. Typing in the search input reveals all matching options.',
+      },
+      source: {
+        code: `import { MultiSelect } from '@chemican/components';
+
+<MultiSelect
+  options={options}
+  placeholder="Select fruits..."
+  maxDisplayedOptions={5}
+/>`,
+      },
+    },
+  },
+};

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -380,6 +380,15 @@ interface MultiSelectProps<T = string | number>
   maxDisplayedOptions?: number;
 
   /**
+   * Total number of options available, used to compute the truncation indicator
+   * count. Set this when `options` is only a server-provided subset (e.g.
+   * server-side search returns a page) so the "+N more" hint reflects the true
+   * total instead of just the loaded options.
+   * Optional, defaults to the number of loaded options.
+   */
+  totalOptionsCount?: number;
+
+  /**
    * Label template for the truncation indicator shown when options exceed maxDisplayedOptions.
    * Receives the number of hidden items as a parameter.
    * Optional, defaults to (count) => `検索テキストを入力して他${count}件を表示`.
@@ -466,6 +475,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
     selectionDisplayMode = 'default',
     hideSelection = false,
     maxDisplayedOptions,
+    totalOptionsCount,
     moreOptionsLabel = (count: number) =>
       `検索テキストを入力して他${count}件を表示`,
     ...props
@@ -997,16 +1007,20 @@ const MultiSelectInner = <T extends string | number = string | number>(
                     return null;
                   }
 
-                  // Always use the render function (either custom or default)
+                  // Always use the render function (either custom or default).
+                  // Render through a keyed Fragment rather than a wrapper div so
+                  // the Tag stays a direct flex child and its `max-w-full` +
+                  // `truncate` resolve against the badge row, not an
+                  // unconstrained wrapper that grows to fit its content.
                   return (
-                    <div key={value}>
+                    <React.Fragment key={value}>
                       {effectiveRenderOption({
                         option,
                         location: 'badge',
                         onRemove: () => toggleOption(value),
                         disabled,
                       })}
-                    </div>
+                    </React.Fragment>
                   );
                 })
                 .filter(Boolean)}
@@ -1148,7 +1162,10 @@ const MultiSelectInner = <T extends string | number = string | number>(
                       (sum, g) => sum + g.options.length,
                       0
                     );
-                    const hiddenCount = totalOptions - visibleCount;
+                    // Use the server total when provided so the hint reflects
+                    // every available option, not just the loaded subset.
+                    const hiddenCount =
+                      (totalOptionsCount ?? totalOptions) - visibleCount;
                     return (
                       <>
                         {groups.map((group) => {
@@ -1217,8 +1234,11 @@ const MultiSelectInner = <T extends string | number = string | number>(
                               selectedValues.includes(opt.value)
                           )
                         : options;
+                      // Use the server total when provided so the hint reflects
+                      // every available option, not just the loaded subset.
                       const hiddenCount =
-                        options.length - visibleOptions.length;
+                        (totalOptionsCount ?? options.length) -
+                        visibleOptions.length;
                       return (
                         <>
                           {visibleOptions.map((option) => {

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -350,6 +350,22 @@ interface MultiSelectProps<T = string | number>
   onValueChange?: (value: T[]) => void;
 
   /**
+   * Maximum number of options to display before the user starts searching.
+   * When set and the total exceeds this number, only the first N options are shown
+   * with an indicator for the remaining items. Selected items always remain visible.
+   * All matching options are shown when searching.
+   * Optional, defaults to undefined (show all).
+   */
+  maxDisplayedOptions?: number;
+
+  /**
+   * Label template for the truncation indicator shown when options exceed maxDisplayedOptions.
+   * Receives the number of hidden items as a parameter.
+   * Optional, defaults to (count) => `検索テキストを入力して他${count}件を表示`.
+   */
+  moreOptionsLabel?: (count: number) => React.ReactNode;
+
+  /**
    * Callback fired when the Apply button is clicked in the popover footer.
    * Receives the array of currently selected values.
    * Optional, called only when user confirms their selection.
@@ -425,6 +441,9 @@ const MultiSelectInner = <T extends string | number = string | number>(
     customTrigger,
     selectionDisplayMode = 'default',
     hideSelection = false,
+    maxDisplayedOptions,
+    moreOptionsLabel = (count: number) =>
+      `検索テキストを入力して他${count}件を表示`,
     ...props
   }: MultiSelectProps<T>,
   ref: React.Ref<MultiSelectRef<T>>
@@ -741,6 +760,9 @@ const MultiSelectInner = <T extends string | number = string | number>(
 
   // Use provided renderOption or fall back to default
   const effectiveRenderOption = renderOption || defaultRenderOption;
+
+  const isSearching = Boolean(searchValue.trim());
+  const shouldTruncate = maxDisplayedOptions !== undefined && !isSearching;
 
   React.useEffect(() => {
     if (!resetOnDefaultValueChange) return;
@@ -1059,76 +1081,140 @@ const MultiSelectInner = <T extends string | number = string | number>(
                 </CommandGroup>
               )}
               {isGroupedOptions(options) ? (
-                options.map((group) => (
-                  <CommandGroup key={group.heading} heading={group.heading}>
-                    {group.options.map((option) => {
-                      const isSelected = selectedValues.includes(option.value);
-                      return (
-                        <CommandItem
-                          key={option.value}
-                          value={`${option.value}:${option.label}`}
-                          onSelect={() => toggleOption(option.value)}
-                          role="option"
-                          aria-selected={isSelected}
-                          aria-disabled={option.disabled ?? false}
-                          aria-label={`${option.label}${
-                            isSelected ? ', selected' : ', not selected'
-                          }${option.disabled ? ', disabled' : ''}`}
-                          className={cn(
-                            'cursor-pointer',
-                            option.disabled &&
-                              `text-interactive-disabled cursor-not-allowed
-                                opacity-100 data-[disabled=true]:opacity-100`
-                          )}
-                          disabled={Boolean(option.disabled)}
-                        >
-                          <Checkbox className="mr-xs" checked={isSelected} />
-                          <span className="min-w-0 overflow-hidden">
-                            {effectiveRenderOption({
-                              option,
-                              location: 'dropdown',
-                              isSelected,
+                (() => {
+                  let rendered = 0;
+                  const totalOptions = options.reduce(
+                    (sum, g) => sum + g.options.length,
+                    0
+                  );
+                  const groups = options.map((group) => {
+                    const visibleOptions = shouldTruncate
+                      ? group.options.filter(
+                          (opt) =>
+                            rendered++ < maxDisplayedOptions! ||
+                            selectedValues.includes(opt.value)
+                        )
+                      : group.options;
+                    return { ...group, options: visibleOptions };
+                  });
+                  const visibleCount = groups.reduce(
+                    (sum, g) => sum + g.options.length,
+                    0
+                  );
+                  const hiddenCount = totalOptions - visibleCount;
+                  return (
+                    <>
+                      {groups.map((group) => {
+                        if (group.options.length === 0) return null;
+                        return (
+                          <CommandGroup
+                            key={group.heading}
+                            heading={group.heading}
+                          >
+                            {group.options.map((option) => {
+                              const isSelected = selectedValues.includes(
+                                option.value
+                              );
+                              return (
+                                <CommandItem
+                                  key={option.value}
+                                  value={`${option.value}:${option.label}`}
+                                  onSelect={() => toggleOption(option.value)}
+                                  role="option"
+                                  aria-selected={isSelected}
+                                  aria-disabled={option.disabled ?? false}
+                                  aria-label={`${option.label}${
+                                    isSelected ? ', selected' : ', not selected'
+                                  }${option.disabled ? ', disabled' : ''}`}
+                                  className={cn(
+                                    'cursor-pointer',
+                                    option.disabled &&
+                                      `text-interactive-disabled cursor-not-allowed opacity-100 data-[disabled=true]:opacity-100`
+                                  )}
+                                  disabled={Boolean(option.disabled)}
+                                >
+                                  <Checkbox
+                                    className="mr-xs"
+                                    checked={isSelected}
+                                  />
+                                  <span className="min-w-0 overflow-hidden">
+                                    {effectiveRenderOption({
+                                      option,
+                                      location: 'dropdown',
+                                      isSelected,
+                                    })}
+                                  </span>
+                                </CommandItem>
+                              );
                             })}
-                          </span>
-                        </CommandItem>
-                      );
-                    })}
-                  </CommandGroup>
-                ))
+                          </CommandGroup>
+                        );
+                      })}
+                      {shouldTruncate && hiddenCount > 0 && (
+                        <div className="text-body-secondary px-lg py-sm text-sm italic">
+                          {moreOptionsLabel(hiddenCount)}
+                        </div>
+                      )}
+                    </>
+                  );
+                })()
               ) : (
                 <CommandGroup>
-                  {options.map((option) => {
-                    const isSelected = selectedValues.includes(option.value);
+                  {(() => {
+                    const visibleOptions = shouldTruncate
+                      ? options.filter(
+                          (opt, i) =>
+                            i < maxDisplayedOptions! ||
+                            selectedValues.includes(opt.value)
+                        )
+                      : options;
+                    const hiddenCount = options.length - visibleOptions.length;
                     return (
-                      <CommandItem
-                        key={option.value}
-                        value={`${option.value}:${option.label}`}
-                        onSelect={() => toggleOption(option.value)}
-                        role="option"
-                        aria-selected={isSelected}
-                        aria-disabled={option.disabled ?? false}
-                        aria-label={`${option.label}${
-                          isSelected ? ', selected' : ', not selected'
-                        }${option.disabled ? ', disabled' : ''}`}
-                        className={cn(
-                          'cursor-pointer',
-                          option.disabled &&
-                            `text-interactive-disabled cursor-not-allowed
-                              opacity-100 data-[disabled=true]:opacity-100`
+                      <>
+                        {visibleOptions.map((option) => {
+                          const isSelected = selectedValues.includes(
+                            option.value
+                          );
+                          return (
+                            <CommandItem
+                              key={option.value}
+                              value={`${option.value}:${option.label}`}
+                              onSelect={() => toggleOption(option.value)}
+                              role="option"
+                              aria-selected={isSelected}
+                              aria-disabled={option.disabled ?? false}
+                              aria-label={`${option.label}${
+                                isSelected ? ', selected' : ', not selected'
+                              }${option.disabled ? ', disabled' : ''}`}
+                              className={cn(
+                                'cursor-pointer',
+                                option.disabled &&
+                                  `text-interactive-disabled cursor-not-allowed opacity-100 data-[disabled=true]:opacity-100`
+                              )}
+                              disabled={Boolean(option.disabled)}
+                            >
+                              <Checkbox
+                                className="mr-xs"
+                                checked={isSelected}
+                              />
+                              <span className="min-w-0 overflow-hidden">
+                                {effectiveRenderOption({
+                                  option,
+                                  location: 'dropdown',
+                                  isSelected,
+                                })}
+                              </span>
+                            </CommandItem>
+                          );
+                        })}
+                        {shouldTruncate && hiddenCount > 0 && (
+                          <div className="text-body-secondary px-lg py-sm text-sm italic">
+                            {moreOptionsLabel(hiddenCount)}
+                          </div>
                         )}
-                        disabled={Boolean(option.disabled)}
-                      >
-                        <Checkbox className="mr-xs" checked={isSelected} />
-                        <span className="min-w-0 overflow-hidden">
-                          {effectiveRenderOption({
-                            option,
-                            location: 'dropdown',
-                            isSelected,
-                          })}
-                        </span>
-                      </CommandItem>
+                      </>
                     );
-                  })}
+                  })()}
                 </CommandGroup>
               )}
             </CommandList>

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { IconChevronDown, IconLoader2 } from '@tabler/icons-react';
+import { IconChevronDown } from '@tabler/icons-react';
 
 import { cn } from '../../lib/utils';
 import { Button } from '../Button';
 import { Tag } from '../Tag';
+import { ProgressIndicator } from '../ProgressIndicator';
 import {
   Popover,
   PopoverContent,
@@ -1099,8 +1100,9 @@ const MultiSelectInner = <T extends string | number = string | number>(
                   className="px-md py-lg text-body-secondary gap-xs text-sm flex
                     items-center justify-center"
                 >
-                  <IconLoader2 className="h-4 w-4 animate-spin" />
-                  {loadingLabel}
+                  <ProgressIndicator.Circular size="sm">
+                    {loadingLabel}
+                  </ProgressIndicator.Circular>
                 </div>
               )}
 

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { IconChevronDown } from '@tabler/icons-react';
+import { IconChevronDown, IconLoader2 } from '@tabler/icons-react';
 
 import { cn } from '../../lib/utils';
 import { Button } from '../Button';
@@ -350,6 +350,27 @@ interface MultiSelectProps<T = string | number>
   onValueChange?: (value: T[]) => void;
 
   /**
+   * Callback fired whenever the search input value changes.
+   * Use this to drive server-side search. When provided, the component disables
+   * its built-in client-side filtering so the parent fully controls `options`.
+   * Optional.
+   */
+  onSearchValueChange?: (search: string) => void;
+
+  /**
+   * If true, shows a loading indicator inside the dropdown instead of the
+   * options list. Useful while options are being fetched (e.g. server-side
+   * search). Optional, defaults to false.
+   */
+  loading?: boolean;
+
+  /**
+   * Label displayed next to the spinner while `loading` is true.
+   * Optional, defaults to "読み込み中..." (Loading...).
+   */
+  loadingLabel?: React.ReactNode;
+
+  /**
    * Maximum number of options to display before the user starts searching.
    * When set and the total exceeds this number, only the first N options are shown
    * with an indicator for the remaining items. Selected items always remain visible.
@@ -403,6 +424,9 @@ const MultiSelectInner = <T extends string | number = string | number>(
   {
     options,
     onValueChange = (value) => value,
+    onSearchValueChange,
+    loading = false,
+    loadingLabel = '読み込み中...',
     onApplySelection = (value) => value,
     variant,
     defaultValue = [] as T[],
@@ -762,7 +786,13 @@ const MultiSelectInner = <T extends string | number = string | number>(
   const effectiveRenderOption = renderOption || defaultRenderOption;
 
   const isSearching = Boolean(searchValue.trim());
-  const shouldTruncate = maxDisplayedOptions !== undefined && !isSearching;
+  // In client-side mode, typing reveals every match so truncation is lifted while
+  // searching. In server-side mode (onSearchValueChange) the parent already
+  // returns a limited page, so keep truncating the displayed results even while
+  // searching.
+  const shouldTruncate =
+    maxDisplayedOptions !== undefined &&
+    (!isSearching || Boolean(onSearchValueChange));
 
   React.useEffect(() => {
     if (!resetOnDefaultValueChange) return;
@@ -1020,7 +1050,9 @@ const MultiSelectInner = <T extends string | number = string | number>(
           }}
           align="start"
         >
-          <Command filter={filterItems}>
+          {/* When the parent handles search (onSearchValueChange), disable the
+              built-in client-side filtering so it controls `options` directly. */}
+          <Command filter={filterItems} shouldFilter={!onSearchValueChange}>
             {searchable && (
               <header>
                 <div id={`${multiSelectId}-search-help`} className="sr-only">
@@ -1030,7 +1062,10 @@ const MultiSelectInner = <T extends string | number = string | number>(
                   placeholder={searchPlaceholder}
                   onKeyDown={handleInputKeyDown}
                   value={searchValue}
-                  onValueChange={setSearchValue}
+                  onValueChange={(value) => {
+                    setSearchValue(value);
+                    onSearchValueChange?.(value);
+                  }}
                   aria-label={searchAriaLabel}
                   aria-describedby={`${multiSelectId}-search-help`}
                 />
@@ -1044,9 +1079,20 @@ const MultiSelectInner = <T extends string | number = string | number>(
               )}
               style={{ overscrollBehaviorY: 'contain' }}
             >
-              <CommandEmpty>{emptyIndicator}</CommandEmpty>
+              {loading && (
+                <div
+                  role="status"
+                  className="px-md py-lg text-body-secondary gap-xs text-sm flex
+                    items-center justify-center"
+                >
+                  <IconLoader2 className="h-4 w-4 animate-spin" />
+                  {loadingLabel}
+                </div>
+              )}
 
-              {!hideSelectAll && !searchValue && (
+              {!loading && <CommandEmpty>{emptyIndicator}</CommandEmpty>}
+
+              {!loading && !hideSelectAll && !searchValue && (
                 <CommandGroup>
                   <CommandItem
                     key="all"
@@ -1080,131 +1126,77 @@ const MultiSelectInner = <T extends string | number = string | number>(
                   </CommandItem>
                 </CommandGroup>
               )}
-              {isGroupedOptions(options) ? (
-                (() => {
-                  let rendered = 0;
-                  const totalOptions = options.reduce(
-                    (sum, g) => sum + g.options.length,
-                    0
-                  );
-                  const groups = options.map((group) => {
-                    const visibleOptions = shouldTruncate
-                      ? group.options.filter(
-                          (opt) =>
-                            rendered++ < maxDisplayedOptions! ||
-                            selectedValues.includes(opt.value)
-                        )
-                      : group.options;
-                    return { ...group, options: visibleOptions };
-                  });
-                  const visibleCount = groups.reduce(
-                    (sum, g) => sum + g.options.length,
-                    0
-                  );
-                  const hiddenCount = totalOptions - visibleCount;
-                  return (
-                    <>
-                      {groups.map((group) => {
-                        if (group.options.length === 0) return null;
-                        return (
-                          <CommandGroup
-                            key={group.heading}
-                            heading={group.heading}
-                          >
-                            {group.options.map((option) => {
-                              const isSelected = selectedValues.includes(
-                                option.value
-                              );
-                              return (
-                                <CommandItem
-                                  key={option.value}
-                                  value={`${option.value}:${option.label}`}
-                                  onSelect={() => toggleOption(option.value)}
-                                  role="option"
-                                  aria-selected={isSelected}
-                                  aria-disabled={option.disabled ?? false}
-                                  aria-label={`${option.label}${
-                                    isSelected ? ', selected' : ', not selected'
-                                  }${option.disabled ? ', disabled' : ''}`}
-                                  className={cn(
-                                    'cursor-pointer',
-                                    option.disabled &&
-                                      `text-interactive-disabled cursor-not-allowed opacity-100 data-[disabled=true]:opacity-100`
-                                  )}
-                                  disabled={Boolean(option.disabled)}
-                                >
-                                  <Checkbox
-                                    className="mr-xs"
-                                    checked={isSelected}
-                                  />
-                                  <span className="min-w-0 overflow-hidden">
-                                    {effectiveRenderOption({
-                                      option,
-                                      location: 'dropdown',
-                                      isSelected,
-                                    })}
-                                  </span>
-                                </CommandItem>
-                              );
-                            })}
-                          </CommandGroup>
-                        );
-                      })}
-                      {shouldTruncate && hiddenCount > 0 && (
-                        <div className="text-body-secondary px-lg py-sm text-sm italic">
-                          {moreOptionsLabel(hiddenCount)}
-                        </div>
-                      )}
-                    </>
-                  );
-                })()
-              ) : (
-                <CommandGroup>
-                  {(() => {
-                    const visibleOptions = shouldTruncate
-                      ? options.filter(
-                          (opt, i) =>
-                            i < maxDisplayedOptions! ||
-                            selectedValues.includes(opt.value)
-                        )
-                      : options;
-                    const hiddenCount = options.length - visibleOptions.length;
+              {!loading &&
+                (isGroupedOptions(options) ? (
+                  (() => {
+                    let rendered = 0;
+                    const totalOptions = options.reduce(
+                      (sum, g) => sum + g.options.length,
+                      0
+                    );
+                    const groups = options.map((group) => {
+                      const visibleOptions = shouldTruncate
+                        ? group.options.filter(
+                            (opt) =>
+                              rendered++ < maxDisplayedOptions! ||
+                              selectedValues.includes(opt.value)
+                          )
+                        : group.options;
+                      return { ...group, options: visibleOptions };
+                    });
+                    const visibleCount = groups.reduce(
+                      (sum, g) => sum + g.options.length,
+                      0
+                    );
+                    const hiddenCount = totalOptions - visibleCount;
                     return (
                       <>
-                        {visibleOptions.map((option) => {
-                          const isSelected = selectedValues.includes(
-                            option.value
-                          );
+                        {groups.map((group) => {
+                          if (group.options.length === 0) return null;
                           return (
-                            <CommandItem
-                              key={option.value}
-                              value={`${option.value}:${option.label}`}
-                              onSelect={() => toggleOption(option.value)}
-                              role="option"
-                              aria-selected={isSelected}
-                              aria-disabled={option.disabled ?? false}
-                              aria-label={`${option.label}${
-                                isSelected ? ', selected' : ', not selected'
-                              }${option.disabled ? ', disabled' : ''}`}
-                              className={cn(
-                                'cursor-pointer',
-                                option.disabled &&
-                                  `text-interactive-disabled cursor-not-allowed opacity-100 data-[disabled=true]:opacity-100`
-                              )}
-                              disabled={Boolean(option.disabled)}
+                            <CommandGroup
+                              key={group.heading}
+                              heading={group.heading}
                             >
-                              <Checkbox
-                                className="mr-xs"
-                                checked={isSelected}
-                              />
-                              <span className="min-w-0 overflow-hidden">
-                                {effectiveRenderOption({
-                                  option,
-                                  location: 'dropdown',
-                                  isSelected,
-                                })}
-                              </span>
-                            </CommandItem>
+                              {group.options.map((option) => {
+                                const isSelected = selectedValues.includes(
+                                  option.value
+                                );
+                                return (
+                                  <CommandItem
+                                    key={option.value}
+                                    value={`${option.value}:${option.label}`}
+                                    onSelect={() => toggleOption(option.value)}
+                                    role="option"
+                                    aria-selected={isSelected}
+                                    aria-disabled={option.disabled ?? false}
+                                    aria-label={`${option.label}${
+                                      isSelected
+                                        ? ', selected'
+                                        : ', not selected'
+                                    }${option.disabled ? ', disabled' : ''}`}
+                                    className={cn(
+                                      'cursor-pointer',
+                                      option.disabled &&
+                                        `text-interactive-disabled cursor-not-allowed opacity-100 data-[disabled=true]:opacity-100`
+                                    )}
+                                    disabled={Boolean(option.disabled)}
+                                  >
+                                    <Checkbox
+                                      className="mr-xs"
+                                      checked={isSelected}
+                                    />
+                                    <span className="min-w-0 overflow-hidden">
+                                      {effectiveRenderOption({
+                                        option,
+                                        location: 'dropdown',
+                                        isSelected,
+                                      })}
+                                    </span>
+                                  </CommandItem>
+                                );
+                              })}
+                            </CommandGroup>
                           );
                         })}
                         {shouldTruncate && hiddenCount > 0 && (
@@ -1214,9 +1206,67 @@ const MultiSelectInner = <T extends string | number = string | number>(
                         )}
                       </>
                     );
-                  })()}
-                </CommandGroup>
-              )}
+                  })()
+                ) : (
+                  <CommandGroup>
+                    {(() => {
+                      const visibleOptions = shouldTruncate
+                        ? options.filter(
+                            (opt, i) =>
+                              i < maxDisplayedOptions! ||
+                              selectedValues.includes(opt.value)
+                          )
+                        : options;
+                      const hiddenCount =
+                        options.length - visibleOptions.length;
+                      return (
+                        <>
+                          {visibleOptions.map((option) => {
+                            const isSelected = selectedValues.includes(
+                              option.value
+                            );
+                            return (
+                              <CommandItem
+                                key={option.value}
+                                value={`${option.value}:${option.label}`}
+                                onSelect={() => toggleOption(option.value)}
+                                role="option"
+                                aria-selected={isSelected}
+                                aria-disabled={option.disabled ?? false}
+                                aria-label={`${option.label}${
+                                  isSelected ? ', selected' : ', not selected'
+                                }${option.disabled ? ', disabled' : ''}`}
+                                className={cn(
+                                  'cursor-pointer',
+                                  option.disabled &&
+                                    `text-interactive-disabled cursor-not-allowed opacity-100 data-[disabled=true]:opacity-100`
+                                )}
+                                disabled={Boolean(option.disabled)}
+                              >
+                                <Checkbox
+                                  className="mr-xs"
+                                  checked={isSelected}
+                                />
+                                <span className="min-w-0 overflow-hidden">
+                                  {effectiveRenderOption({
+                                    option,
+                                    location: 'dropdown',
+                                    isSelected,
+                                  })}
+                                </span>
+                              </CommandItem>
+                            );
+                          })}
+                          {shouldTruncate && hiddenCount > 0 && (
+                            <div className="text-body-secondary px-lg py-sm text-sm italic">
+                              {moreOptionsLabel(hiddenCount)}
+                            </div>
+                          )}
+                        </>
+                      );
+                    })()}
+                  </CommandGroup>
+                ))}
             </CommandList>
 
             <footer

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -358,7 +358,7 @@ export const Tag: React.FC<TagProps> = ({
       {Boolean(onRemove) && !disabled && (
         <button
           className={cn(
-            `bg-interactive-neutral-default h-3 w-3 flex cursor-pointer
+            `bg-interactive-neutral-default h-3 w-3 flex shrink-0 cursor-pointer
             items-center justify-center rounded-full leading-none`
           )}
           onClick={onRemove}


### PR DESCRIPTION
## Issue information
<img width="428" height="451" alt="image" src="https://github.com/user-attachments/assets/62816edf-e509-4087-a085-db52832017f1" />

## Overview

Adds a `maxDisplayedOptions` feature to MultiSelect that limits the number of visible options in long lists to reduce visual clutter.

**New props:**
- `maxDisplayedOptions` - cap on visible options before searching (default: unlimited)
- `moreOptionsLabel` - text for the truncation indicator (default: `検索テキストを入力して他${count}件を表示`)

**Behavior:**
- Only the first N options are shown by default with a text hint for the remaining items
- Selected items always remain visible regardless of the cap
- All matching options are revealed when the user starts searching
- Works for both flat and grouped options

## Dependencies

- None

## Steps to Test

- Open Storybook and navigate to MultiSelect > MaxDisplayedOptions
  - Verify only 5 options are shown with a truncation message
  - Type in the search input - verify all matching options appear
  - Select an option beyond the visible list (via search), clear search - verify it remains visible
  - Verify the hidden count updates correctly as items are selected