### PR TITLE
feat(Select): Add fullWidthOptions props

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -127,19 +127,6 @@ UserSelector.args = {
   placeholder: 'ユーザーを選択',
 };
 
-export const FullWidthOptions = Template.bind({});
-FullWidthOptions.args = {
-  variant: 'default',
-  icon: IconBuilding,
-  fullWidthOptions: true,
-  options: [
-    { value: 'chemican', label: 'Chemican inc.' },
-    { value: 'long-company', label: '株式会社化学化学化学化学' },
-    { value: 'aaa-company', label: 'AAA企業' },
-  ],
-  placeholder: 'Select company',
-};
-
 export const DisabledStates = Template.bind({});
 DisabledStates.args = {
   variant: 'default',

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -127,6 +127,19 @@ UserSelector.args = {
   placeholder: 'ユーザーを選択',
 };
 
+export const FullWidthOptions = Template.bind({});
+FullWidthOptions.args = {
+  variant: 'default',
+  icon: IconBuilding,
+  fullWidthOptions: true,
+  options: [
+    { value: 'chemican', label: 'Chemican inc.' },
+    { value: 'long-company', label: '株式会社化学化学化学化学' },
+    { value: 'aaa-company', label: 'AAA企業' },
+  ],
+  placeholder: 'Select company',
+};
+
 export const DisabledStates = Template.bind({});
 DisabledStates.args = {
   variant: 'default',

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -134,6 +134,11 @@ export interface SelectProps<T extends number | string = string>
   hideChevron?: boolean;
   searchPlaceholder?: string;
   searchThreshold?: number;
+  /**
+   * Forces the options list to match the width of the trigger exactly,
+   * overriding any minimum-width constraints from the variant.
+   */
+  fullWidthOptions?: boolean;
 }
 
 export const Select = <T extends number | string = string>({
@@ -149,6 +154,7 @@ export const Select = <T extends number | string = string>({
   onValueChange,
   searchPlaceholder = 'Search...',
   searchThreshold = 7,
+  fullWidthOptions = false,
   ...props
 }: SelectProps<T>) => {
   const [searchValue, setSearchValue] = React.useState('');
@@ -253,7 +259,12 @@ export const Select = <T extends number | string = string>({
         <RadixSelect.Content
           position="popper"
           sideOffset={-1} // Needed to not have the 1px spacing because of the borders.
-          className={cn(selectContentVariants({ variant }), className)}
+          className={cn(
+            selectContentVariants({ variant }),
+            fullWidthOptions &&
+              'min-w-0 w-[var(--radix-select-trigger-width)] max-w-none',
+            className
+          )}
         >
           {showSearch && (
             <div

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -56,9 +56,9 @@ const selectContentVariants = cva(
     variants: {
       variant: {
         default: `border-interactive-default max-h-96 rounded
-        w-[var(--radix-select-trigger-width)]`,
+        min-w-[var(--radix-select-trigger-width)]`,
         compact: `border-divider-default max-h-96 rounded-sm
-        min-w-[max(12rem,var(--radix-select-trigger-width))]
+        min-w-[var(--radix-select-trigger-width)]
         shadow-[0px_5px_9px_0px_rgba(0,0,0,0.16)]`,
       },
     },
@@ -134,11 +134,6 @@ export interface SelectProps<T extends number | string = string>
   hideChevron?: boolean;
   searchPlaceholder?: string;
   searchThreshold?: number;
-  /**
-   * Forces the options list to match the width of the trigger exactly,
-   * overriding any minimum-width constraints from the variant.
-   */
-  fullWidthOptions?: boolean;
 }
 
 export const Select = <T extends number | string = string>({
@@ -154,7 +149,6 @@ export const Select = <T extends number | string = string>({
   onValueChange,
   searchPlaceholder = 'Search...',
   searchThreshold = 7,
-  fullWidthOptions = false,
   ...props
 }: SelectProps<T>) => {
   const [searchValue, setSearchValue] = React.useState('');
@@ -259,12 +253,7 @@ export const Select = <T extends number | string = string>({
         <RadixSelect.Content
           position="popper"
           sideOffset={-1} // Needed to not have the 1px spacing because of the borders.
-          className={cn(
-            selectContentVariants({ variant }),
-            fullWidthOptions &&
-              'min-w-0 w-[var(--radix-select-trigger-width)] max-w-none',
-            className
-          )}
+          className={cn(selectContentVariants({ variant }), className)}
         >
           {showSearch && (
             <div


### PR DESCRIPTION
## issue information
Created a `fullWidthOptions: boolean` props for `Select` component.
When this one is set to `true` the options list will be the same width as the `Select` trigger.

## Test
Created a new story under the `Select.stories.tsx`