### PR TITLE
fix(Table): Add proper z-index for table header stickiness

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -72,7 +72,10 @@ const TableHeader = React.forwardRef<HTMLTableSectionElement, TableHeaderProps>(
     return (
       <thead
         ref={ref}
-        className={cn('text-sm bg-surface-tertiary top-0 sticky', className)}
+        className={cn(
+          'text-sm bg-surface-tertiary top-0 z-slight sticky',
+          className
+        )}
         {...props}
       >
         {children}


### PR DESCRIPTION
## issue information
Fix the visual stickiness of the Table header component.

Reported with this conversation: https://chemican.slack.com/archives/C087SK9AWHF/p1782701395545139