### PR TITLE
fix(Switch): Make thumb visible in disabled unchecked state

### DIFF
--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -37,7 +37,8 @@ const Switch = React.forwardRef<
         data-slot="switch-thumb"
         className={cn(
           `data-[state=checked]:bg-shape-interactive-inverse size-4
-          data-[state=unchecked]:bg-shape-accent-gray-pale
+          data-[state=unchecked]:not-data-disabled:bg-shape-accent-gray-pale
+          data-[state=unchecked]:data-disabled:bg-shape-interactive-inverse
           data-[state=checked]:translate-x-5
           data-[state=unchecked]:translate-x-1 pointer-events-none block
           rounded-full ring-0 transition-transform`


### PR DESCRIPTION
## Issue information

Reported directly in local testing (no ticket).

## Overview

In the disabled unchecked state, the Switch knob was invisible: both the track (`bg-interactive-disabled`) and the thumb (`bg-shape-accent-gray-pale`) resolve to `neutral-200` in both themes. The thumb now uses the inverse (white) shape token when disabled and unchecked, matching the disabled checked state which already renders a white knob.

## Dependencies

Any consumer rendering a disabled, unchecked Switch.

## Steps to Test

- Run Storybook and open the Switch stories
- Render a Switch with `disabled` and unchecked → knob is white and visible
- Verify enabled unchecked (pale gray knob) and disabled checked (white knob) are unchanged

## Additional Information

Uses Radix's `data-disabled` attribute on the Thumb, since the thumb is a `span` and has no native `:disabled` state.

<sub>This PR description was generated by Claude after consultation with @kschiffer, after they reported the invisible disabled unchecked Switch knob in local testing.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)