### PR TITLE
feat(Tag): Add asChild prop to render tags as links

### DIFF
--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -140,6 +140,20 @@ DisabledWithIcon.args = {
   disabled: true,
 };
 
+export const AsChild: StoryFn = () => (
+  <div className="gap-2 flex flex-wrap">
+    <Tag colorCode={8} asChild>
+      <a href="#link">リンクタグ</a>
+    </Tag>
+    <Tag colorCode={2} variant="secondary" asChild>
+      <a href="#link">セカンダリリンク</a>
+    </Tag>
+    <Tag colorCode={19} icon={IconStar} asChild>
+      <a href="#link">アイコン付きリンク</a>
+    </Tag>
+  </div>
+);
+
 export const ColorCodeShowcase: StoryFn<{
   selected?: boolean;
   variant?: 'primary' | 'secondary';

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Slot } from 'radix-ui';
 import { cva } from 'class-variance-authority';
 
 import { ColorShapeTokens, ColorTextTokens } from '../../tokens';
@@ -242,6 +243,11 @@ export interface TagProps {
   variant?: 'primary' | 'secondary';
   icon?: IconProp;
   disabled?: boolean;
+  /**
+   * Whether to render as a child element, e.g. a link (useful for Next.js Link).
+   * The child element receives the tag styling; `icon` and `onRemove` render inside it.
+   */
+  asChild?: boolean;
 }
 
 const tagVariants = cva(
@@ -301,6 +307,7 @@ export const Tag: React.FC<TagProps> = ({
   variant = 'primary',
   icon,
   disabled = false,
+  asChild = false,
 }) => {
   const colorMapping = colorCodeToTokenMap.find(
     (colorMap) => colorMap.code === colorCode
@@ -317,30 +324,36 @@ export const Tag: React.FC<TagProps> = ({
     return `var(${colorMapping?.textColor})`;
   };
 
+  const tagClassName = cn(
+    tagVariants({
+      size,
+      selected: disabled ? false : selected,
+      interactive: Boolean(onClick) && !disabled,
+      variant,
+      disabled,
+    }),
+    className
+  );
+
+  const tagStyle: React.CSSProperties = {
+    // Only apply accent background for primary variant
+    // Secondary variant uses bg-surface-disabled from CVA (or bg-interactive-disabled when disabled)
+    ...(variant === 'primary' && {
+      backgroundColor: `var(${colorMapping?.backgroundColor})`,
+    }),
+    // Only apply inline color when not disabled (Tailwind class handles disabled state)
+    ...(!disabled && { color: `var(${colorMapping?.textColor})` }),
+    ...style,
+  };
+
+  const Comp = asChild ? Slot.Slot : 'div';
+
   return (
-    <div
-      className={cn(
-        tagVariants({
-          size,
-          selected: disabled ? false : selected,
-          interactive: Boolean(onClick) && !disabled,
-          variant,
-          disabled,
-        }),
-        className
-      )}
-      style={{
-        // Only apply accent background for primary variant
-        // Secondary variant uses bg-surface-disabled from CVA (or bg-interactive-disabled when disabled)
-        ...(variant === 'primary' && {
-          backgroundColor: `var(${colorMapping?.backgroundColor})`,
-        }),
-        // Only apply inline color when not disabled (Tailwind class handles disabled state)
-        ...(!disabled && { color: `var(${colorMapping?.textColor})` }),
-        ...style,
-      }}
+    <Comp
+      className={tagClassName}
+      style={tagStyle}
       onClick={disabled ? undefined : onClick}
-      role={onClick ? 'button' : undefined}
+      role={!asChild && onClick ? 'button' : undefined}
       aria-disabled={disabled || undefined}
     >
       {icon && (
@@ -354,7 +367,11 @@ export const Tag: React.FC<TagProps> = ({
           {renderIcon(icon, { size: 14 })}
         </span>
       )}
-      <div className="pt-0.5 relative h-full truncate">{children}</div>
+      {asChild ? (
+        <Slot.Slottable>{children}</Slot.Slottable>
+      ) : (
+        <div className="pt-0.5 relative h-full truncate">{children}</div>
+      )}
       {Boolean(onRemove) && !disabled && (
         <button
           className={cn(
@@ -378,6 +395,6 @@ export const Tag: React.FC<TagProps> = ({
           </svg>
         </button>
       )}
-    </div>
+    </Comp>
   );
 };


### PR DESCRIPTION
## Issue information

N/A

## Overview

Adds an `asChild` prop to the `Tag` component so it can render as a link (e.g. Next.js `Link`) while keeping the tag look and behavior:

```tsx
<Tag colorCode={8} icon={IconStar} asChild>
  <Link href="/tags/8">タグ名</Link>
</Tag>
```

Implemented with Radix `Slot`/`Slottable`: the child element becomes the tag root and receives all styling and handlers, while `icon` and the `onRemove` button still render inside it. This matches the `asChild` pattern already used by `Button` and `TextLink`.

Notes:
- In `asChild` mode the internal truncate wrapper is not applied, so long labels won't ellipsize unless handled in the child.
- Combining `onRemove` with a link will trigger navigation on remove-click unless the handler calls `preventDefault`.

## Dependencies

Tag component only. Non-`asChild` rendering is unchanged apart from an internal refactor (shared className/style variables).

## Steps to Test

- Run `npm run storybook`
- Open Components/Tag → AsChild: tags render as anchors with correct styling, including icon variant
- Check existing Tag stories for regressions (icon, remove button, disabled, selected)

## Additional Information

<details>
<summary>Conversation summary</summary>

The initial implementation followed the `TextLink` precedent where `asChild` drops `icon`/`onRemove`. Kevin clarified the goal was to render full tags as links, so it was reworked to use `Slot.Slottable`, which keeps the icon and remove button while making the child element the root.

</details>

<sub>This PR description was generated by Claude in consultation with Kevin, after Kevin requested `asChild` link support for the Tag component.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)