### PR TITLE
feat(Breadcrumbs): Add per-item asChild for custom link rendering

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -120,23 +120,22 @@ SingleItem.args = {
   size: 'sm',
 };
 
-// Stand-in for a router link component such as Next.js Link
-const CustomLink: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({
-  children,
-  ...props
-}) => (
-  <a {...props} onClick={(e) => e.preventDefault()} data-custom-link>
+// Stand-in for a router link component such as Next.js Link or
+// React Router / TanStack Router Link
+const CustomLink: React.FC<
+  React.AnchorHTMLAttributes<HTMLAnchorElement> & { to: string }
+> = ({ children, to, ...props }) => (
+  <a {...props} href={to} onClick={(e) => e.preventDefault()} data-custom-link>
     {children}
   </a>
 );
 
-export const WithLinkComponent = Template.bind({});
-WithLinkComponent.args = {
+export const WithAsChildItems = Template.bind({});
+WithAsChildItems.args = {
   items: [
-    { label: 'ホーム', href: '/' },
-    { label: '製品', href: '/products' },
+    { label: <CustomLink to="/">ホーム</CustomLink>, asChild: true },
+    { label: <CustomLink to="/products">製品</CustomLink>, asChild: true },
     { label: '現在のページ' },
   ],
-  linkComponent: CustomLink,
   size: 'sm',
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -119,3 +119,24 @@ SingleItem.args = {
   items: [{ label: 'Current Page' }],
   size: 'sm',
 };
+
+// Stand-in for a router link component such as Next.js Link
+const CustomLink: React.FC<React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+  children,
+  ...props
+}) => (
+  <a {...props} onClick={(e) => e.preventDefault()} data-custom-link>
+    {children}
+  </a>
+);
+
+export const WithLinkComponent = Template.bind({});
+WithLinkComponent.args = {
+  items: [
+    { label: 'ホーム', href: '/' },
+    { label: '製品', href: '/products' },
+    { label: '現在のページ' },
+  ],
+  linkComponent: CustomLink,
+  size: 'sm',
+};

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Slot } from 'radix-ui';
 import type { VariantProps } from 'class-variance-authority';
 import { cva } from 'class-variance-authority';
 import { IconChevronRight } from '@tabler/icons-react';
@@ -50,6 +51,13 @@ export interface BreadcrumbItem {
   label: React.ReactNode;
   href?: string;
   onClick?: () => void;
+  /**
+   * Render `label` as the crumb element itself via Radix Slot. Useful for
+   * router links, e.g. `{ label: <Link to="/">ホーム</Link>, asChild: true }`.
+   * The element receives the crumb styling and `aria-current`; `href` is
+   * ignored since the element provides its own navigation.
+   */
+  asChild?: boolean;
 }
 
 export interface BreadcrumbsProps
@@ -59,13 +67,6 @@ export interface BreadcrumbsProps
   separator?: React.ComponentType<{ className?: string }>;
   maxItems?: number;
   'aria-label'?: string;
-  /**
-   * Component used to render crumb links instead of a plain anchor
-   * (useful for Next.js Link). Applied to items with an `href`.
-   */
-  linkComponent?: React.ElementType<
-    React.AnchorHTMLAttributes<HTMLAnchorElement>
-  >;
 }
 
 export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
@@ -77,7 +78,6 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
       maxItems,
       className,
       'aria-label': ariaLabel = 'breadcrumb',
-      linkComponent,
       ...props
     },
     ref
@@ -102,9 +102,6 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
           {displayItems.map((item, index) => {
             const isLast = index === displayItems.length - 1;
             const isEllipsis = item.label === '…';
-            // Custom link components (e.g. Next.js Link) require an href,
-            // so onClick-only items keep the plain anchor
-            const LinkComp = (item.href && linkComponent) || 'a';
 
             return (
               <React.Fragment key={`${item.label}-${index}`}>
@@ -115,8 +112,18 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
                     >
                       {item.label}
                     </span>
+                  ) : item.asChild ? (
+                    <Slot.Slot
+                      onClick={item.onClick}
+                      className={cn(
+                        breadcrumbItemVariants({ isActive: isLast })
+                      )}
+                      aria-current={isLast ? 'page' : undefined}
+                    >
+                      {item.label}
+                    </Slot.Slot>
                   ) : item.href || item.onClick ? (
-                    <LinkComp
+                    <a
                       href={item.href}
                       onClick={item.onClick}
                       className={cn(
@@ -125,7 +132,7 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
                       aria-current={isLast ? 'page' : undefined}
                     >
                       {item.label}
-                    </LinkComp>
+                    </a>
                   ) : (
                     <span
                       className={cn(breadcrumbItemVariants({ isActive: true }))}

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -59,6 +59,13 @@ export interface BreadcrumbsProps
   separator?: React.ComponentType<{ className?: string }>;
   maxItems?: number;
   'aria-label'?: string;
+  /**
+   * Component used to render crumb links instead of a plain anchor
+   * (useful for Next.js Link). Applied to items with an `href`.
+   */
+  linkComponent?: React.ElementType<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>
+  >;
 }
 
 export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
@@ -70,6 +77,7 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
       maxItems,
       className,
       'aria-label': ariaLabel = 'breadcrumb',
+      linkComponent,
       ...props
     },
     ref
@@ -94,6 +102,9 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
           {displayItems.map((item, index) => {
             const isLast = index === displayItems.length - 1;
             const isEllipsis = item.label === '…';
+            // Custom link components (e.g. Next.js Link) require an href,
+            // so onClick-only items keep the plain anchor
+            const LinkComp = (item.href && linkComponent) || 'a';
 
             return (
               <React.Fragment key={`${item.label}-${index}`}>
@@ -105,7 +116,7 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
                       {item.label}
                     </span>
                   ) : item.href || item.onClick ? (
-                    <a
+                    <LinkComp
                       href={item.href}
                       onClick={item.onClick}
                       className={cn(
@@ -114,7 +125,7 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
                       aria-current={isLast ? 'page' : undefined}
                     >
                       {item.label}
-                    </a>
+                    </LinkComp>
                   ) : (
                     <span
                       className={cn(breadcrumbItemVariants({ isActive: true }))}


### PR DESCRIPTION
## Issue information

N/A

## Overview

Adds an `asChild` option to `BreadcrumbItem` so crumbs can render via any router link component instead of a plain `<a>`, enabling client-side navigation:

```tsx
<Breadcrumbs
  items={[
    { label: <Link to="/">ホーム</Link>, asChild: true },
    { label: <Link to="/products">製品</Link>, asChild: true },
    { label: '現在のページ' },
  ]}
/>
```

With `asChild: true`, the `label` element becomes the crumb itself via Radix `Slot`, receiving the crumb styling and `aria-current`. Since the consumer provides the element, this works with any router (Next.js, React Router, TanStack Router).

> [!NOTE]
> An earlier revision used a `linkComponent` prop, but per review feedback that only worked for `href`-based links like Next.js `Link` — router links using `to` (React Router, TanStack) wouldn't fit. Reworked to `asChild`/`Slot` in 2cf786c4d.

Related: #156 added the equivalent capability to `Tag` via `asChild`.

## Dependencies

Breadcrumbs component only. Items without `asChild` render unchanged.

## Steps to Test

- Run `npm run storybook`
- Open Components/Breadcrumbs → WithAsChildItems: crumbs render the provided link elements with crumb styling (inspect for `data-custom-link`)
- Check existing Breadcrumbs stories for regressions (click handlers, truncation, single item)

## Additional Information

<sub>This PR description was generated by Claude in consultation with Kevin, after Kevin asked for router link support in Breadcrumbs following the Tag asChild work.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
