### PR TITLE
fix(MultiSelect): Show no-options message instead of select-all when empty

### DIFF
--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -421,16 +421,21 @@ export const Disabled: Story = {
   },
 };
 
+export const NoOptions: Story = {
+  args: {
+    options: [],
+    placeholder: 'No options...',
+    onValueChange: (values) => console.log('Selected values:', values),
+  },
+};
+
 export const CustomEmptyState: Story = {
   args: {
     options: [],
-    emptyIndicator: (
+    noOptionsIndicator: (
       <div className="py-6 flex flex-col items-center text-center">
         <IconStar className="h-12 w-12 text-body-secondary mb-2" />
         <p className="text-body-secondary">No options available</p>
-        <p className="text-xs text-body-secondary mt-1">
-          Try a different search term
-        </p>
       </div>
     ),
     placeholder: 'Custom empty state...',

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -175,6 +175,13 @@ interface MultiSelectProps<T = string | number>
   emptyIndicator?: React.ReactNode;
 
   /**
+   * Message shown in the popover when the component has no options at all.
+   * In that case the select-all option is not rendered either.
+   * Optional, defaults to "No options available."
+   */
+  noOptionsIndicator?: React.ReactNode;
+
+  /**
    * Placeholder text shown in the search input when search is enabled.
    * Optional, defaults to "Search options...".
    */
@@ -459,6 +466,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
     hideSelectAll = false,
     searchable = true,
     emptyIndicator = '結果が見つかりません。',
+    noOptionsIndicator = '利用可能なオプションがありません。',
     autoSize = false,
     singleLine = false,
     popoverClassName,
@@ -796,6 +804,7 @@ const MultiSelectInner = <T extends string | number = string | number>(
   // Use provided renderOption or fall back to default
   const effectiveRenderOption = renderOption || defaultRenderOption;
 
+  const hasOptions = getAllOptions().length > 0;
   const isSearching = Boolean(searchValue.trim());
   // In client-side mode, typing reveals every match so truncation is lifted while
   // searching. In server-side mode (onSearchValueChange) the parent already
@@ -1106,9 +1115,21 @@ const MultiSelectInner = <T extends string | number = string | number>(
                 </div>
               )}
 
-              {!loading && <CommandEmpty>{emptyIndicator}</CommandEmpty>}
+              {!loading && (hasOptions || isSearching) && (
+                <CommandEmpty>{emptyIndicator}</CommandEmpty>
+              )}
 
-              {!loading && !hideSelectAll && !searchValue && (
+              {!loading && !hasOptions && !isSearching && (
+                <div
+                  role="status"
+                  className="px-md py-lg text-body-secondary text-sm flex
+                    items-center justify-center"
+                >
+                  {noOptionsIndicator}
+                </div>
+              )}
+
+              {!loading && !hideSelectAll && !searchValue && hasOptions && (
                 <CommandGroup>
                   <CommandItem
                     key="all"


### PR DESCRIPTION
## Issue information

N/A

## Overview

With an empty options list, the MultiSelect dropdown rendered only the "(すべて選択)" meta item, which is misleading since there is nothing to select. Now:

- A new `noOptionsIndicator` prop (default: `利用可能なオプションがありません。`) is shown when the component has no options.
- The select-all option is not rendered in that case.
- While a search is active, the existing `emptyIndicator` still takes precedence — important for server-side search (`onSearchValueChange`), where an empty options array means "no results for this query" rather than "no options exist".

## Dependencies

MultiSelect component only. Behavior with a non-empty options list is unchanged. The `CustomEmptyState` story was migrated from `emptyIndicator` to `noOptionsIndicator` since the search-empty slot no longer renders for an empty options list.

## Steps to Test

- Run `npm run storybook`
- Open Components/MultiSelect → NoOptions: dropdown shows the default no-options message, no select-all row
- CustomEmptyState: shows the custom no-options node
- Existing stories with options: select-all and search empty state behave as before

## Additional Information

<sub>This PR description was generated by Claude in consultation with Kevin, after Kevin reported that an empty MultiSelect still rendered the select-all meta option.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)